### PR TITLE
Display the subtitle stream for a given session

### DIFF
--- a/src/pages/components/sessions/session-card.js
+++ b/src/pages/components/sessions/session-card.js
@@ -73,8 +73,7 @@ function sessionCard(props) {
 
           <Card.Body  className="w-100 h-100 p-1 pb-2" >
             <Container className="h-100 d-flex flex-column">
-              <Row className="d-flex flex-row flex-grow-1 justify-content-between">
-
+              <Row className="d-flex flex-row flex-grow-1 justify-content-between" style={{fontSize: "smaller"}}>
                   <Col className="col-auto">
                     <Row className="ellipse"> {props.data.session.DeviceName}</Row>
                     <Row className="ellipse card-client-version"> {props.data.session.Client + " " + props.data.session.ApplicationVersion}</Row>
@@ -82,7 +81,9 @@ function sessionCard(props) {
                       <Col className="px-0 col-auto">{props.data.session.PlayState.PlayMethod}</Col> 
                       <Col className="px-0 px-md-2 col-auto ellipse">{(props.data.session.NowPlayingItem.MediaStreams ? '( '+props.data.session.NowPlayingItem.MediaStreams.find(stream => stream.Type==='Video')?.Codec.toUpperCase()+(props.data.session.TranscodingInfo? ' - '+props.data.session.TranscodingInfo.VideoCodec.toUpperCase() : '')+' - '+convertBitrate(props.data.session.TranscodingInfo ? props.data.session.TranscodingInfo.Bitrate :props.data.session.NowPlayingItem.MediaStreams.find(stream => stream.Type==='Video')?.BitRate)+' )':'')}</Col>
                     </Row>
-                    
+                    <Row className="ellipse">
+                      <Col className="px-0 col-auto">{props.data.session.NowPlayingItem.SubtitleStream}</Col>
+                    </Row>
                   </Col>
 
 

--- a/src/pages/components/sessions/sessions.js
+++ b/src/pages/components/sessions/sessions.js
@@ -24,6 +24,26 @@ function Sessions() {
       }
     };
 
+    const getSubtitleStream = (row) => {
+        let result = 'No subtitles';
+
+        if(!row.PlayState) {
+          return result;
+        }
+
+        let subStreamIndex = row.PlayState.SubtitleStreamIndex;
+
+        if(subStreamIndex == undefined || subStreamIndex === -1) {
+          return result;
+        }
+        
+        if(row.NowPlayingItem.MediaStreams && row.NowPlayingItem.MediaStreams.length) {
+          result = `Subtitles: ${row.NowPlayingItem.MediaStreams[subStreamIndex].DisplayTitle}`;
+        }
+
+        return result;
+    }
+
     const fetchData = () => {
 
       if (config) {
@@ -39,7 +59,9 @@ function Sessions() {
           .then((data) => {
             if(data && typeof data.data === 'object' && Array.isArray(data.data))
             {
-              setData(data.data.filter(row => row.NowPlayingItem !== undefined));
+              let toSet = data.data.filter(row => row.NowPlayingItem !== undefined);
+              toSet.forEach(s => s.NowPlayingItem.SubtitleStream = getSubtitleStream(s));
+              setData(toSet);
             }
 
           })


### PR DESCRIPTION
If no subtitles, display this in the sessions card.

Reduced the font size of playback details to prevent the card getting too crowded.