### PR TITLE
add links to last-watched-card

### DIFF
--- a/src/pages/components/general/last-watched-card.js
+++ b/src/pages/components/general/last-watched-card.js
@@ -61,8 +61,11 @@ function LastWatchedCard(props) {
           </Link>
         </div>
 
-        <div className="last-item-name"> {props.data.Name}</div>
-        <div className="last-item-episode"> {props.data.EpisodeName}</div>
+        <div className="last-item-name">
+          <Link to={`/libraries/item/${props.data.Id}`}>{props.data.Name}</Link>
+        </div>
+        <div className="last-item-episode">
+          <Link to={`/libraries/item/${props.data.EpisodeId}`}>{props.data.EpisodeName}</Link></div>
       </div>
       {props.data.SeasonNumber ?
          <div className="last-item-episode number"> S{props.data.SeasonNumber} -  E{props.data.EpisodeNumber}</div>:

--- a/src/pages/css/sessions.css
+++ b/src/pages/css/sessions.css
@@ -92,8 +92,7 @@
     border-radius: 50%;
     max-width: 30px;
     max-height: 30px;
-
-
+    margin-right: 5px;
 }
 
 .card-user-image-default


### PR DESCRIPTION
QoL changes:
- Show/Movie title will take you to the show/movie in Jellystat
- Episode title will take you to the episode in Jellystat Aesthetic changes:
- Small margin added between user pic and username on session card
![image](https://github.com/CyferShepard/Jellystat/assets/35006874/2803dd86-d963-4d84-99e0-48b2ef1bffe9)
