### PR TITLE
fix NaN for live tv playback

### DIFF
--- a/src/pages/components/sessions/session-card.js
+++ b/src/pages/components/sessions/session-card.js
@@ -71,6 +71,10 @@ function SessionCard(props) {
     height:'100%',
   };
 
+  const pushNextToBottom = {
+    'margin-bottom': 'auto'
+  }
+
   const token = localStorage.getItem('token');
 
   const ipv4Regex = new RegExp(/\b(?!(10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168))(?:(?:2(?:[0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9])\.){3}(?:(?:2([0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9]))\b/);
@@ -203,7 +207,7 @@ function SessionCard(props) {
 
              
                 
-                <Row className="d-flex flex-row justify-content-between">
+                <Row className="d-flex flex-row justify-content-between" style={pushNextToBottom}>
                     {props.data.session.NowPlayingItem.Type==='Episode' ? 
                       <Col className="col-auto p-0">
                                <Card.Text >
@@ -262,7 +266,7 @@ function SessionCard(props) {
                 <Card.Text className="text-end">
                   <Tooltip title={`Ends at ${getETAFromTicks(props.data.session.NowPlayingItem.RunTimeTicks - props.data.session.PlayState.PositionTicks)}`}>
                     <span> 
-                      {ticksToTimeString(props.data.session.PlayState.PositionTicks)} /
+                      {ticksToTimeString(props.data.session.PlayState.PositionTicks)}/
                       {ticksToTimeString(props.data.session.NowPlayingItem.RunTimeTicks)} 
                     </span>
                   </Tooltip>

--- a/src/pages/components/sessions/sessions.js
+++ b/src/pages/components/sessions/sessions.js
@@ -24,7 +24,16 @@ function Sessions() {
       }
     };
 
-    const getSubtitleStream = (row) => {
+    const handleLiveTV = row => {
+      //Handle live events
+      let nowPlaying = row.NowPlayingItem;
+      if(!nowPlaying.RunTimeTicks && nowPlaying?.CurrentProgram) {
+        nowPlaying.RunTimeTicks = 0;
+        nowPlaying.Name = `${nowPlaying.Name}: ${nowPlaying.CurrentProgram.Name}`;
+      }
+    };
+
+    const getSubtitleStream = row => {
       let result = '';
 
       if(!row.PlayState) {
@@ -42,7 +51,7 @@ function Sessions() {
       }
 
       return result;
-  }
+    };
 
     const fetchData = () => {
 
@@ -61,7 +70,10 @@ function Sessions() {
             if(data && typeof data.data === 'object' && Array.isArray(data.data))
             {
               let toSet = data.data.filter(row => row.NowPlayingItem !== undefined);
-              toSet.forEach(s => s.NowPlayingItem.SubtitleStream = getSubtitleStream(s));
+              toSet.forEach(s => {
+                handleLiveTV(s);
+                s.NowPlayingItem.SubtitleStream = getSubtitleStream(s);                
+              });
               setData(toSet);
             }
 

--- a/src/pages/components/sessions/sessions.js
+++ b/src/pages/components/sessions/sessions.js
@@ -25,7 +25,6 @@ function Sessions() {
     };
 
     const handleLiveTV = row => {
-      //Handle live events
       let nowPlaying = row.NowPlayingItem;
       if(!nowPlaying.RunTimeTicks && nowPlaying?.CurrentProgram) {
         nowPlaying.RunTimeTicks = 0;


### PR DESCRIPTION
Jellyfin reports playback for live tv with an end time of 00:00:00, replicating this in Jellystat.

Also add the current program name to the now playing item

Also some aesthetic changes to ensure playback counter row is always at the bottom of the card

![image](https://github.com/CyferShepard/Jellystat/assets/35006874/a7507b3a-4699-4f5d-9816-cf54d007b7a2)

NB: Jellyfin itself seems to have a bug where the CurrentProgram item does not update when a program ends and the next one starts. If this is fixed, instead of 00:00:00, the current program's start/end times could be used to display how far along the user is relative to those.