### PR TITLE
Fix Stretched Music Album Covers

### DIFF
--- a/src/pages/components/sessions/session-card.jsx
+++ b/src/pages/components/sessions/session-card.jsx
@@ -129,7 +129,11 @@ function SessionCard(props) {
         <Col className="d-none d-lg-block stat-card-banner">
               <Card.Img
                 variant="top"
-                className="stat-card-image rounded-0 rounded-start"
+                className={props.data.session.NowPlayingItem.Type==='Audio' ? (
+                  "stat-card-image-audio rounded-0 rounded-start"
+                ) : (
+                  "stat-card-image rounded-0 rounded-start"
+                )}
                 src={"/proxy/Items/Images/Primary?id=" + (props.data.session.NowPlayingItem.SeriesId ? props.data.session.NowPlayingItem.SeriesId : props.data.session.NowPlayingItem.Id) + "&fillHeight=320&fillWidth=213&quality=50"}
               />
 

--- a/src/pages/components/statCards/ItemStatComponent.jsx
+++ b/src/pages/components/statCards/ItemStatComponent.jsx
@@ -53,7 +53,11 @@ function ItemStatComponent(props) {
                 )}
                 {!props.data[0].archived ?
                 <Card.Img
-                  className="stat-card-image"
+                  className={props.isAudio ? (
+                    "stat-card-image-audio rounded-0 rounded-start"
+                  ) : (
+                    "stat-card-image rounded-0 rounded-start"
+                  )}
                   src={"proxy/Items/Images/Primary?id=" + props.data[0].Id + "&fillWidth=400&quality=90"}
                   style={{ display: loaded ? 'block' : 'none' }}
                   onLoad={handleImageLoad}

--- a/src/pages/components/statCards/mp_music.jsx
+++ b/src/pages/components/statCards/mp_music.jsx
@@ -69,7 +69,7 @@ function MPMusic(props) {
 
 
   return (
-    <ItemStatComponent  base_url={config.hostUrl} data={data} heading={"MOST POPULAR MUSIC"} units={"Users"}/>
+    <ItemStatComponent  base_url={config.hostUrl} data={data} heading={"MOST POPULAR MUSIC"} units={"Users"} isAudio={true}/>
   );
 }
 

--- a/src/pages/components/statCards/mv_music.jsx
+++ b/src/pages/components/statCards/mv_music.jsx
@@ -68,7 +68,7 @@ function MVMovies(props) {
 
 
   return (
-    <ItemStatComponent base_url={config.hostUrl} data={data} heading={"MOST LISTENED MUSIC"} units={"Plays"}/>
+    <ItemStatComponent base_url={config.hostUrl} data={data} heading={"MOST LISTENED MUSIC"} units={"Plays"} isAudio={true}/>
   );
 }
 

--- a/src/pages/css/statCard.css
+++ b/src/pages/css/statCard.css
@@ -22,9 +22,11 @@
   max-width: 120px !important;
 }
 
-
-
-
+.stat-card-image-audio {
+  width: 120px !important;
+  top: 15%;
+  position: relative;
+}
 
 .stat-card-image {
   width: 120px !important;


### PR DESCRIPTION
Hey @CyferShepard! Great job on JellyStats!

Here's a quick PR to fix to fix music album covers which were stretched on the home page. It is fixing both the session and stats cards.

**Before**

![Capture d’écran du 2023-12-08 23-50-15](https://github.com/CyferShepard/Jellystat/assets/8635747/afcfb398-ebad-4259-bc3c-1aba10bba121)

**After**

![Capture d’écran du 2023-12-08 23-50-06](https://github.com/CyferShepard/Jellystat/assets/8635747/a8f8c840-2d3b-42f2-92b7-b7485f4ad01e)
