### PR TITLE
[Feature] Implement DNS Caching of HTTP Queries

### DIFF
--- a/backend/classes/axios.js
+++ b/backend/classes/axios.js
@@ -1,17 +1,20 @@
 const axios = require("axios");
 const https = require('https');
+const CacheableLookup = require('cacheable-lookup');
+
+const cacheable = new CacheableLookup();
 
 const agent = new https.Agent({
-    rejectUnauthorized: (process.env.REJECT_SELF_SIGNED_CERTIFICATES || 'true').toLowerCase() ==='true'
-  });
+  rejectUnauthorized: (process.env.REJECT_SELF_SIGNED_CERTIFICATES || 'true').toLowerCase() === 'true'
+});
 
+cacheable.install(agent);
 
 const axios_instance = axios.create({
-    httpsAgent: agent
-  });
+  httpsAgent: agent
+});
 
-  module.exports =
-  {
-    axios:axios_instance
-  };
-  
+module.exports =
+{
+  axios: axios_instance
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "axios": "^1.5.1",
         "axios-cache-interceptor": "^1.3.1",
         "bootstrap": "^5.2.3",
-        "cacheable-lookup": "^7.0.0",
+        "cacheable-lookup": "^6.1.0",
         "compare-versions": "^6.0.0-rc.1",
         "compression": "^1.7.4",
         "config": "^3.3.9",
@@ -7348,11 +7348,11 @@
       "integrity": "sha512-O0KwuHuJnbHUrghHi2kGp0SxnWSIBXTYt7M8WVhW0kbPRUNUKoE/Of6e1rRD6AAxmfxFunKnt90yEK09D+sc5g=="
     },
     "node_modules/cacheable-lookup": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=10.6.0"
       }
     },
     "node_modules/call-bind": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "axios": "^1.5.1",
         "axios-cache-interceptor": "^1.3.1",
         "bootstrap": "^5.2.3",
+        "cacheable-lookup": "^7.0.0",
         "compare-versions": "^6.0.0-rc.1",
         "compression": "^1.7.4",
         "config": "^3.3.9",
@@ -7345,6 +7346,14 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.4.tgz",
       "integrity": "sha512-O0KwuHuJnbHUrghHi2kGp0SxnWSIBXTYt7M8WVhW0kbPRUNUKoE/Of6e1rRD6AAxmfxFunKnt90yEK09D+sc5g=="
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "engines": {
+        "node": ">=14.16"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "axios": "^1.5.1",
     "axios-cache-interceptor": "^1.3.1",
     "bootstrap": "^5.2.3",
+    "cacheable-lookup": "^7.0.0",
     "compare-versions": "^6.0.0-rc.1",
     "compression": "^1.7.4",
     "config": "^3.3.9",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "axios": "^1.5.1",
     "axios-cache-interceptor": "^1.3.1",
     "bootstrap": "^5.2.3",
-    "cacheable-lookup": "^7.0.0",
+    "cacheable-lookup": "^6.1.0",
     "compare-versions": "^6.0.0-rc.1",
     "compression": "^1.7.4",
     "config": "^3.3.9",


### PR DESCRIPTION
Looks like Axios is not caching any DNS resolution by default. By adding the [cacheable-lookup](https://github.com/szmarczak/cacheable-lookup) lib and enabling it on the http agent, it will greatly reduce calls to DNS during sync/update operations in Jellystat.

Ran a quick test using my own DNS server to see how much DNS queries were made with and without cacheable-lookup lib.

For a full Jellyfin sync I would always reach the query cap on Pi-Hole, which is 1000 queries per hour. It would start replying errors at around 20% of the sync.

With the cacheable-lookup, I was able to run the full sync up to 100%. There were less than 50 queries to my DNS server for the whole process.

Should fix the DNS Spamming issue mentionned in #101.