### PR TITLE
Unstable

### DIFF
--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -630,11 +630,17 @@ router.post("/getUserHistory", async (req, res) => {
 router.post("/validateSettings", async (req, res) => {
   const { url, apikey } = req.body;
 
+  var _url=url;
+  _url = _url.replace(/\/web\/index\.html#!\/home\.html$/, '');
+  if (!/^https?:\/\//i.test(url)) {
+    _url = 'http://' + url;
+  }
+
   let isValid = false;
   let errorMessage = "";
   try {
     await axios
-      .get(url + "/system/configuration", {
+      .get(_url + "/system/configuration", {
         headers: {
           "X-MediaBrowser-Token": apikey,
         },
@@ -657,6 +663,9 @@ router.post("/validateSettings", async (req, res) => {
         } else if (error.response && error.response.status === 404) {
           isValid = false;
           errorMessage = `Error ${error.response.status}: The requested URL was not found.`;
+        } else if (error.code === "EPROTO") {
+          isValid = false;
+          errorMessage = `Error: Network protocol mismatch. Please check your url.`;
         } else {
           isValid = false;
           errorMessage = `${error}`;

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "start-client": "vite --host",
     "start-server": "cd backend && nodemon server.js",
-    "start-app": "concurrently \"npm run start-server\" \"npm run start-client\"",
+    "start-dev": "concurrently \"npm run start-server\" \"npm run start-client\"",
     "deploy-local": "npm run build && npm run start-server",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "build": "vite build",
+    "start-app": "cd backend && node server.js",
     "start": "cd backend && node server.js"
   },
   "dependencies": {


### PR DESCRIPTION
Small fix where older installs of Jellystat used the `start-app` command in the docker container.  `start-app` has been changed to be a duplicate of `start` and the old functionality moved to a command called `start-dev`

URL cleanup code added to v`alidateSettings` endpoint to handle certain use-cases