### PR TITLE
Add the use of volumes to the example docker compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: mypassword
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
   jellystat:
     image: jellystat
     environment:
@@ -13,7 +15,9 @@ services:
       POSTGRES_IP: jellystat-db
       POSTGRES_PORT: 5432
       JWT_SECRET: 'my-secret-jwt-key'
-      TZ: Africa/Johannesburg  
+      TZ: Africa/Johannesburg
+    volumes:
+      - jellystat-backup-data:/app/backend/backup-data
     ports:
       - "3000:3000"
     depends_on:
@@ -25,3 +29,7 @@ logging:
       options:
         max-file: "5"   # number of files or file count
         max-size: "10m" # file size
+
+volumes:
+  postgres-data:
+  jellystat-backup-data:


### PR DESCRIPTION
Please allow me to use this space to say: Great job! I really like your UI and this project is really useful for me. Thanks!

This is a minor change that updates the `docker-compose.yml` file to add persistance. Embarrasingly, I did a pull and a restart which recreated my containers and blew away all the historical data. I should have thought about this when adding the configuration to my compose constellation but I am human and I make mistakes. 

Hopefully, having these configuration parameters in the example will help remind people when they are deploying using docker compose.
