### PR TITLE
Docker Secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ FROM node:slim
 WORKDIR /app
 
 COPY --from=builder /app .
+COPY --chmod=755 entry.sh /entry.sh
 
 EXPOSE 3000
 
-CMD ["npm", "run", "start"]
+CMD ["/entry.sh"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ When contributing please ensure to log a pull request on the `unstable` branch
 Check out our dockerhub to run Jellystat:
 https://hub.docker.com/r/cyfershepard/jellystat
 
+### Environment variables from files (Docker secrets)
+You can set any environment variable from a file by using the prefix `FILE__`
+
+As an example:
+```yaml
+  jellystat:
+    environment:
+      FILE__MYVAR: /run/secrets/MYSECRETFILE
+```
+Will set the environment variable `MYVAR` based on the contents of the `/run/secrets/MYSECRETFILE` file. see [docker secrets](https://docs.docker.com/compose/use-secrets/) for more info.
+
 ## Screenshots
 
 <img src="./screenshots/Home.PNG">

--- a/entry.sh
+++ b/entry.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+load_secrets() {
+  # Treat all env vars that start with the prefix 'FILE__' as secrets,
+  # loading their contents into a variable without the prefix.
+
+  # Loop through all env vars starting with 'FILE__'
+  for var in $(env | grep '^FILE__'); do
+    var_name=$(echo "${var}" | cut -d= -f1)
+    var_value=$(echo "${var}" | cut -d= -f2)
+
+    # Ensure var value is a file
+    if [ -f "${var_value}" ]; then
+
+      # Strip 'FILE__' prefix to obtain corresponding variable name
+      new_var_name="${var_name#FILE__}"
+
+      # Notify user if original variable is being overwritten.
+      if [ -n "$(eval echo \$$new_var_name)" ]; then
+        echo "Warning: ${new_var_name} was already set but is being overwritten by $var_name"
+      fi
+      # Set the new variable with the secret value
+      export "${new_var_name}=$(cat "${var_value}")"
+    else
+      echo "Error: Secret file '${var_value}' does not exist"
+      exit 1
+    fi
+  done
+}
+
+# Load secrets
+load_secrets
+# Launch Jellystat
+npm run start


### PR DESCRIPTION
resolves #81 

This implements docker secrets via a shell script. The script loops over all environment variables that are prefixed with `FILE__` (such as `FILE__MYVAR`) and loads the contents of the file that variable points to into a new variable without the prefix (such as MYVAR).


Tested by:
Creating a file called `.jwt_secret` with the contents `'my-secret-jwt-key'`
Then using the following `docker-compose.yaml` performed a `docker compose up`
```yaml
version: '3'
services:
  jellystat-db:
    image: postgres
    environment:
      POSTGRES_USER: postgres
      POSTGRES_PASSWORD: mypassword
  jellystat:
    build:
      context: .
    environment:
      POSTGRES_USER: postgres
      POSTGRES_PASSWORD: mypassword
      POSTGRES_IP: jellystat-db
      POSTGRES_PORT: 5432
      TZ: Africa/Johannesburg
      FILE__JWT_SECRET: /run/secrets/JWT_SECRET
    secrets:
      - JWT_SECRET
    ports:
      - "3000:3000"
    depends_on:
      - jellystat-db
secrets:
  JWT_SECRET:
    file: .jwt_secret
```
Benefits:
The JWT SECRET `'my-secret-jwt-key'` never appears in the yaml file, but docker is directed to mount the `.jwt_secret` file into the container at `/run/secrets/JWT_SECRET` at runtime. Hence no passwords/secrets are in the yaml file or committed to any version control. This can be done for any environment variable you don't want exposed in the docker-compose file.