### PR TITLE
fix: add quotes to postgres user in migrations

### DIFF
--- a/backend/migrations/001_app_config_table.js
+++ b/backend/migrations/001_app_config_table.js
@@ -10,7 +10,7 @@ exports.up = async function(knex) {
       table.text('APP_USER');
       table.text('APP_PASSWORD');
     });
-    await knex.raw(`ALTER TABLE app_config OWNER TO ${process.env.POSTGRES_USER};`);
+    await knex.raw(`ALTER TABLE app_config OWNER TO "${process.env.POSTGRES_USER}";`);
   }
 }catch (error) {
   console.error(error);

--- a/backend/migrations/002_jf_activity_watchdog_table.js
+++ b/backend/migrations/002_jf_activity_watchdog_table.js
@@ -20,7 +20,7 @@ exports.up = async function(knex) {
         table.timestamp('ActivityDateInserted').defaultTo(knex.fn.now());
         table.text('PlayMethod');
       });
-      await knex.raw(`ALTER TABLE jf_activity_watchdog OWNER TO ${process.env.POSTGRES_USER};`);
+      await knex.raw(`ALTER TABLE jf_activity_watchdog OWNER TO "${process.env.POSTGRES_USER}";`);
     }
   } catch (error) {
     console.error(error);

--- a/backend/migrations/003_jf_libraries_table.js
+++ b/backend/migrations/003_jf_libraries_table.js
@@ -11,7 +11,7 @@ exports.up = async function(knex) {
           table.text('CollectionType').notNullable();
           table.text('ImageTagsPrimary');
         });
-        await knex.raw(`ALTER TABLE jf_libraries OWNER TO ${process.env.POSTGRES_USER};`);
+        await knex.raw(`ALTER TABLE jf_libraries OWNER TO "${process.env.POSTGRES_USER}";`);
       }
     } catch (error) {
       console.error(error);

--- a/backend/migrations/004_jf_library_items_table.js
+++ b/backend/migrations/004_jf_library_items_table.js
@@ -22,7 +22,7 @@ exports.up = async function(knex) {
         table.text('ParentId').notNullable().references('Id').inTable('jf_libraries').onDelete('SET NULL').onUpdate('NO ACTION');
         table.text('PrimaryImageHash');
       });
-      await knex.raw(`ALTER TABLE IF EXISTS jf_library_items OWNER TO ${process.env.POSTGRES_USER};`);
+      await knex.raw(`ALTER TABLE IF EXISTS jf_library_items OWNER TO "${process.env.POSTGRES_USER}";`);
 
     }
   } catch (error) {

--- a/backend/migrations/005_jf_library_seasons_table.js
+++ b/backend/migrations/005_jf_library_seasons_table.js
@@ -16,7 +16,7 @@ exports.up = async function(knex) {
         table.text('SeriesPrimaryImageTag');
       });
 
-      await knex.raw(`ALTER TABLE IF EXISTS jf_library_seasons OWNER TO ${process.env.POSTGRES_USER};`);
+      await knex.raw(`ALTER TABLE IF EXISTS jf_library_seasons OWNER TO "${process.env.POSTGRES_USER}";`);
     }
   } catch (error) {
     console.error(error);

--- a/backend/migrations/006_jf_library_episodes_table.js
+++ b/backend/migrations/006_jf_library_episodes_table.js
@@ -24,7 +24,7 @@ exports.up = async function(knex) {
         table.text('SeriesName');
       });
 
-      await knex.raw(`ALTER TABLE IF EXISTS jf_library_episodes OWNER TO ${process.env.POSTGRES_USER};`);
+      await knex.raw(`ALTER TABLE IF EXISTS jf_library_episodes OWNER TO "${process.env.POSTGRES_USER}";`);
     }
   } catch (error) {
     console.error(error);

--- a/backend/migrations/007_jf_playback_activity_table.js
+++ b/backend/migrations/007_jf_playback_activity_table.js
@@ -21,7 +21,7 @@ exports.up = async function(knex) {
         table.text('PlayMethod');
       });
 
-      await knex.raw(`ALTER TABLE IF EXISTS jf_playback_activity OWNER TO ${process.env.POSTGRES_USER};`);
+      await knex.raw(`ALTER TABLE IF EXISTS jf_playback_activity OWNER TO "${process.env.POSTGRES_USER}";`);
     }
   } catch (error) {
     console.error(error);

--- a/backend/migrations/008_js_users_table.js
+++ b/backend/migrations/008_js_users_table.js
@@ -11,7 +11,7 @@
           table.boolean('IsAdministrator');
         });
   
-        await knex.raw(`ALTER TABLE IF EXISTS jf_users OWNER TO ${process.env.POSTGRES_USER};`);;
+        await knex.raw(`ALTER TABLE IF EXISTS jf_users OWNER TO "${process.env.POSTGRES_USER}";`);;
       }
     } catch (error) {
       console.error(error);

--- a/backend/migrations/013_fs_last_user_activity_function.js
+++ b/backend/migrations/013_fs_last_user_activity_function.js
@@ -44,7 +44,7 @@ exports.up = function(knex) {
       $BODY$;
       
       ALTER FUNCTION fs_last_user_activity(text)
-        OWNER TO ${process.env.POSTGRES_USER};
+        OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });

--- a/backend/migrations/014_fs_library_stats_function.js
+++ b/backend/migrations/014_fs_library_stats_function.js
@@ -28,7 +28,7 @@ exports.up = async function(knex) {
       $BODY$;
   
       ALTER FUNCTION fs_library_stats(integer, text)
-          OWNER TO ${process.env.POSTGRES_USER};
+          OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });

--- a/backend/migrations/015_fs_most_active_user_function.js
+++ b/backend/migrations/015_fs_most_active_user_function.js
@@ -20,7 +20,7 @@ exports.up = function(knex) {
       END;
       $BODY$;
       ALTER FUNCTION fs_most_active_user(integer)
-      OWNER TO ${process.env.POSTGRES_USER};
+      OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
       console.error(error);
     });

--- a/backend/migrations/016_fs_most_played_items_function.js
+++ b/backend/migrations/016_fs_most_played_items_function.js
@@ -47,7 +47,7 @@ exports.up = async function(knex) {
       $BODY$;
   
       ALTER FUNCTION fs_most_played_items(integer, text)
-        OWNER TO ${process.env.POSTGRES_USER};
+        OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });

--- a/backend/migrations/017_fs_most_popular_items_function.js
+++ b/backend/migrations/017_fs_most_popular_items_function.js
@@ -53,7 +53,7 @@ exports.up = async function(knex) {
       END;
       $BODY$;
       ALTER FUNCTION fs_most_popular_items(integer, text)
-      OWNER TO ${process.env.POSTGRES_USER};
+      OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });

--- a/backend/migrations/018_fs_most_used_clients_function.js
+++ b/backend/migrations/018_fs_most_used_clients_function.js
@@ -22,7 +22,7 @@ exports.up = async function(knex) {
       $BODY$;
   
       ALTER FUNCTION fs_most_used_clients(integer)
-          OWNER TO ${process.env.POSTGRES_USER};
+          OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
       console.error(error);
     });

--- a/backend/migrations/019_fs_most_viewed_libraries_function.js
+++ b/backend/migrations/019_fs_most_viewed_libraries_function.js
@@ -51,7 +51,7 @@ exports.up = function(knex) {
       $BODY$;
   
       ALTER FUNCTION fs_most_viewed_libraries(integer)
-        OWNER TO ${process.env.POSTGRES_USER};
+        OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });

--- a/backend/migrations/020_fs_user_stats_function.js
+++ b/backend/migrations/020_fs_user_stats_function.js
@@ -32,7 +32,7 @@ exports.up = async function(knex) {
       $BODY$;
   
       ALTER FUNCTION fs_user_stats(integer, text)
-      OWNER TO ${process.env.POSTGRES_USER};
+      OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });

--- a/backend/migrations/021_fs_watch_stats_over_time_functions.js
+++ b/backend/migrations/021_fs_watch_stats_over_time_functions.js
@@ -48,7 +48,7 @@ exports.up = async function (knex) {
       $BODY$;
   
       ALTER FUNCTION fs_watch_stats_over_time(integer)
-        OWNER TO ${process.env.POSTGRES_USER};
+        OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });

--- a/backend/migrations/022_fs_watch_stats_popular_days_of_week_function.js
+++ b/backend/migrations/022_fs_watch_stats_popular_days_of_week_function.js
@@ -56,7 +56,7 @@ exports.up =async function(knex) {
       END;
       $BODY$;
       ALTER FUNCTION fs_watch_stats_popular_days_of_week(integer)
-      OWNER TO ${process.env.POSTGRES_USER};
+      OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });

--- a/backend/migrations/023_fs_watch_stats_popular_hour_of_day_function,js.js
+++ b/backend/migrations/023_fs_watch_stats_popular_hour_of_day_function,js.js
@@ -42,7 +42,7 @@ exports.up =async function(knex) {
     END;
     $BODY$;
     ALTER FUNCTION fs_watch_stats_popular_hour_of_day(integer)
-    OWNER TO ${process.env.POSTGRES_USER};
+    OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });

--- a/backend/migrations/024_jf_item_info_table.js
+++ b/backend/migrations/024_jf_item_info_table.js
@@ -12,7 +12,7 @@ exports.up = async function(knex) {
         table.text('Type');
       });
 
-      await knex.raw(`ALTER TABLE IF EXISTS jf_item_info OWNER TO ${process.env.POSTGRES_USER};`);
+      await knex.raw(`ALTER TABLE IF EXISTS jf_item_info OWNER TO "${process.env.POSTGRES_USER}";`);
     }
   } catch (error) {
     console.error(error);

--- a/backend/migrations/026_fs_last_user_activity_function.js
+++ b/backend/migrations/026_fs_last_user_activity_function.js
@@ -37,7 +37,7 @@ exports.up = function(knex) {
     $BODY$;
 
       ALTER FUNCTION fs_last_user_activity(text)
-        OWNER TO ${process.env.POSTGRES_USER};
+        OWNER TO "${process.env.POSTGRES_USER}";
     `).catch(function(error) {
         console.error(error);
       });
@@ -90,7 +90,7 @@ exports.up = function(knex) {
       $BODY$;
       
       ALTER FUNCTION fs_last_user_activity(text)
-        OWNER TO ${process.env.POSTGRES_USER};
+        OWNER TO "${process.env.POSTGRES_USER}";
     `);
   };
   

--- a/backend/migrations/028_jf_playback_reporting_plugin_data_table.js
+++ b/backend/migrations/028_jf_playback_reporting_plugin_data_table.js
@@ -15,7 +15,7 @@ exports.up = async function(knex) {
         table.bigInteger('PlayDuration');
       });
 
-      await knex.raw(`ALTER TABLE IF EXISTS jf_playback_reporting_plugin_data OWNER TO ${process.env.POSTGRES_USER};`);
+      await knex.raw(`ALTER TABLE IF EXISTS jf_playback_reporting_plugin_data OWNER TO "${process.env.POSTGRES_USER}";`);
     }
   } catch (error) {
     console.error(error);

--- a/backend/migrations/030_jf_logging_table.js
+++ b/backend/migrations/030_jf_logging_table.js
@@ -12,7 +12,7 @@ exports.up = async function(knex) {
           table.json('Log');
           table.text('Result');
         });
-        await knex.raw(`ALTER TABLE jf_logging OWNER TO ${process.env.POSTGRES_USER};`);
+        await knex.raw(`ALTER TABLE jf_logging OWNER TO "${process.env.POSTGRES_USER}";`);
       }
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
Currently migrations are not working for some users. For example, a user with a dot inside his username(`media.jellystat`) will cause errors in SQL queries.

```
error: ALTER TABLE app_config OWNER TO media.jellystat; - syntax error at or near "."
```