### PR TITLE
Fix: Display apple icon correctly for iOS Devices

### DIFF
--- a/src/pages/components/sessions/session-card.jsx
+++ b/src/pages/components/sessions/session-card.jsx
@@ -159,13 +159,16 @@ function SessionCard(props) {
                     <img
                      className="card-device-image"
                      src={
-                    "/proxy/web/assets/img/devices/?devicename=" 
-                    +
-                    (props.data.session.Client.toLowerCase().includes("web") ? 
-                    ( clientData.find(item => props.data.session.DeviceName.toLowerCase().includes(item)) || "other")
-                    :
-                    ( clientData.find(item => props.data.session.Client.toLowerCase().includes(item)) || "other")
-                    )}
+                      "/proxy/web/assets/img/devices/?devicename=" +
+                      (props.data.session.Client.toLowerCase() === "jellyfin mobile (ios)" && props.data.session.DeviceName.toLowerCase() === "iphone" ?
+                        "apple"
+                      :
+                        props.data.session.Client.toLowerCase().includes("web") ? 
+                          ( clientData.find(item => props.data.session.DeviceName.toLowerCase().includes(item)) || "other")
+                        :
+                          ( clientData.find(item => props.data.session.Client.toLowerCase().includes(item)) || "other")
+                      )
+                    }
                     alt=""
                      />
                   </Col>


### PR DESCRIPTION
This resolves a small visual problem in the Sessions summary area on the homepage, where the device icon for users streaming via the iOS Jellyfin app was not displayed correctly. The issue stemmed from the device name being labeled as ios, for which there is no matching asset icon available: https://github.com/jellyfin/jellyfin-web/tree/master/src/assets/img/devices -- see screenshot below:

![Screenshot 2024-04-10 at 22 37 10](https://github.com/CyferShepard/Jellystat/assets/39102261/73fe7b86-8a8f-474b-950d-409d990538a7)


Looking at Jellyfin's API Response for the `/Sessions` endpoint and filtering for a device that's streaming via iOS app, the returned value for `Client` is `Jellyfin Mobile (iOS)`, and `DeviceName` is `iPhone`, therefore this code piece checks if those values match and if so, sets the devicename to "apple" so a valid icon is fetched. Here's the outcome:
![Screenshot 2024-04-10 at 22 46 26](https://github.com/CyferShepard/Jellystat/assets/39102261/f502a2c6-14fb-4c19-b9db-52a6ff781f12)
