### PR TITLE
Adding healthcheck to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,22 @@ RUN npm run build
 # Stage 2: Create the production image
 FROM node:slim
 
+RUN apt-get update && \
+    apt-get install -yqq --no-install-recommends wget && \
+    apt-get autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /app .
 COPY --chmod=755 entry.sh /entry.sh
+
+HEALTHCHECK --interval=30s \
+            --timeout=5s \
+            --start-period=10s \
+            --retries=3 \
+            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/auth/isconfigured" ]
 
 EXPOSE 3000
 


### PR DESCRIPTION
Installing **wget** in the docker image and adding a **HEALTHCHECK** that can be used to verify if the container is up and running.

The new packages add 2MB to the total image size (826MB to 828MB), which I think is reasonable. I also put in some basic values for the healthcheck which all look good on my end, but happy to tweak them if necessary.