### PR TITLE
Adding environment variable to define the minimum number of seconds for a playback to be included

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,25 +24,27 @@
 
 ## Environmental Variables
 
-| Env                             | Default  | Example                         | Description                                                                                                                              |
-| ------------------------------- | -------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| POSTGRES_USER `REQUIRED`        | `null`   | `postgres`                      | Username that will be used in postgres database                                                                                          |
-| POSTGRES_PASSWORD `REQUIRED`    | `null`   | `postgres`                      | Password that will be used in postgres database                                                                                          |
-| POSTGRES_IP `REQUIRED`          | `null`   | `jellystat-db` or `192.168.0.5` | Hostname/IP of postgres instance                                                                                                         |
-| POSTGRES_PORT `REQUIRED`        | `null`   | `5432`                          | Port Postgres is running on                                                                                                              |
-| JWT_SECRET `REQUIRED`           | `null`   | `my-secret-jwt-key`             | JWT Key to be used to encrypt JWT tokens for authentication                                                                              |
-| JS_BASE_URL                     | `/`      | `/`                             | Base url                                                                                                                                 |
-| JS_USER                         | `null`   | `User`                          | Master Override User in case username or password used during setup is forgotten (Both `JS_USER` and `JS_PASSWORD` required to work)     |
-| JS_PASSWORD                     | `null`   | `Password`                      | Master Override Password in case username or password used during setup is forgotten (Both `JS_USER` and `JS_PASSWORD` required to work) |
-| POSTGRES_DB                     | `jfstat` | `jfstat`                        | Name of postgres database                                                                                                                |
-| REJECT_SELF_SIGNED_CERTIFICATES | `true`   | `false`                         | Allow or deny self signed SSL certificates                                                                                               |
-| JS_GEOLITE_ACCOUNT_ID           | `null`   | `123456`                        | maxmind.com user id to be used for Geolocating IP Addresses (Can be found at https://www.maxmind.com/en/accounts/current/edit)           |
-| JS_GEOLITE_LICENSE_KEY          | `null`   | `ASDWdaSdawe2sd186`             | License key you need to generate on maxmind to use their services                                                                        |
+| Env                                 | Default  | Example                         | Description                                                                                                                              |
+|-------------------------------------|----------|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| POSTGRES_USER `REQUIRED`            | `null`   | `postgres`                      | Username that will be used in postgres database                                                                                          |
+| POSTGRES_PASSWORD `REQUIRED`        | `null`   | `postgres`                      | Password that will be used in postgres database                                                                                          |
+| POSTGRES_IP `REQUIRED`              | `null`   | `jellystat-db` or `192.168.0.5` | Hostname/IP of postgres instance                                                                                                         |
+| POSTGRES_PORT `REQUIRED`            | `null`   | `5432`                          | Port Postgres is running on                                                                                                              |
+| JWT_SECRET `REQUIRED`               | `null`   | `my-secret-jwt-key`             | JWT Key to be used to encrypt JWT tokens for authentication                                                                              |
+| TZ `REQUIRED`                       | `null`   | `Etc/UTC`                       | Server timezone (Can be found at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)                                      |
+| JS_BASE_URL                         | `/`      | `/`                             | Base url                                                                                                                                 |
+| JS_USER                             | `null`   | `User`                          | Master Override User in case username or password used during setup is forgotten (Both `JS_USER` and `JS_PASSWORD` required to work)     |
+| JS_PASSWORD                         | `null`   | `Password`                      | Master Override Password in case username or password used during setup is forgotten (Both `JS_USER` and `JS_PASSWORD` required to work) |
+| POSTGRES_DB                         | `jfstat` | `jfstat`                        | Name of postgres database                                                                                                                |
+| REJECT_SELF_SIGNED_CERTIFICATES     | `true`   | `false`                         | Allow or deny self signed SSL certificates                                                                                               |
+| JS_GEOLITE_ACCOUNT_ID               | `null`   | `123456`                        | maxmind.com user id to be used for Geolocating IP Addresses (Can be found at https://www.maxmind.com/en/accounts/current/edit)           |
+| JS_GEOLITE_LICENSE_KEY              | `null`   | `ASDWdaSdawe2sd186`             | License key you need to generate on maxmind to use their services                                                                        |
+| MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK | `1`      | `10`                            | The minimum time (in seconds) to include a playback record, which can be used to exclude short playbacks                                 |
 
 ## Getting Started with Development
 
 - Clone the project from git
-- set your env variables before strating the server (Variable names as per Environmental Variables above).
+- Set your env variables before starting the server (Variable names as per [Environmental Variables](#environmental-variables) above).
 - Run `npm install` to install necessary packages
 - Run `npm run start-server` to only run the backend nodejs server
 - Run `npm run start-client` to only run the frontend React UI

--- a/backend/tasks/ActivityMonitor.js
+++ b/backend/tasks/ActivityMonitor.js
@@ -7,6 +7,7 @@ const configClass = require("../classes/config");
 const API = require("../classes/api-loader");
 const { sendUpdate } = require("../ws");
 const { isNumber } = require("@mui/x-data-grid/internals");
+const MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK = process.env.MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK ? Number(process.env.MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK) : 1;
 
 async function getSessionsInWatchDog(SessionData, WatchdogData) {
   let existingData = await WatchdogData.filter((wdData) => {
@@ -180,7 +181,7 @@ async function ActivityMonitor(interval) {
       let ExistingDataToUpdate = [];
 
       //for each item in playbackToInsert, check if it exists in the recent playback activity and update accordingly. insert new row if updating existing exceeds the runtime
-      if (playbackToInsert.length > 0 && ExistingRecords.length > 0) {
+      if (playbackToInsert.length >= MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK && ExistingRecords.length >= MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK) {
         ExistingDataToUpdate = playbackToInsert.filter((playbackData) => {
           const existingrow = ExistingRecords.find((existing) => {
             let newDurationWithingRunTime = true;
@@ -211,7 +212,7 @@ async function ActivityMonitor(interval) {
       //remove items from playbackToInsert that already exists in the recent playback activity so it doesnt duplicate or where PlaybackDuration===0
       playbackToInsert = playbackToInsert.filter(
         (pb) =>
-          pb.PlaybackDuration > 0 &&
+          pb.PlaybackDuration >= MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK &&
           !ExistingRecords.some(
             (er) => er.NowPlayingItemId === pb.NowPlayingItemId && er.EpisodeId === pb.EpisodeId && er.UserId === pb.UserId
           )
@@ -219,7 +220,7 @@ async function ActivityMonitor(interval) {
 
       //remove items where PlaybackDuration===0
 
-      ExistingDataToUpdate = ExistingDataToUpdate.filter((pb) => pb.PlaybackDuration > 0);
+      ExistingDataToUpdate = ExistingDataToUpdate.filter((pb) => pb.PlaybackDuration >= MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK);
 
       if (toDeleteIds.length > 0) {
         await db.deleteBulk("jf_activity_watchdog", toDeleteIds, "ActivityId");


### PR DESCRIPTION
Allows for filtering out playbacks that only execute for a second or two (like during testing, or when a new episode auto-plays). The new variable is called 'MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK'.

Potential resolution for https://github.com/CyferShepard/Jellystat/issues/270.