### PR TITLE
Added limit attribute for getHistory, getLibraryHistory and getUserHi…

### DIFF
--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -1735,6 +1735,11 @@
             "name": "req",
             "in": "query",
             "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string"
           }
         ],
         "responses": {
@@ -1770,6 +1775,11 @@
           },
           {
             "name": "req",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
             "in": "query",
             "type": "string"
           },
@@ -1880,6 +1890,11 @@
           },
           {
             "name": "req",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
             "in": "query",
             "type": "string"
           },


### PR DESCRIPTION
Added a limit attribute to api for getHistory, getLibraryHistory and getUserHistory. I added this based on the limit value in getRecentlyAdded. Option is not required and defaults to 50. Not sure if that was the correct value to use or not.

The other thing I changed that could be removed is sorting the getUserHistory by descending order by date watched similar to getHistory. That is the only change that may be breaking if people are using this api call.

I initially tried adding it to the data base query but that doesn't work since the results had to be grouped. Moved this to the groupActivity call passing in the limit to stop after x number of entries have been added to the response.

Tested this extensively with the swagger ui. 

First time contributing so I am not sure your rules for requesting or posting a feature. If you do not feel this is needed please feel free to close this request.

Thanks for the great app!