### PR TITLE
Split out Video and Audio into different columns.

### DIFF
--- a/src/pages/components/sessions/session-card.jsx
+++ b/src/pages/components/sessions/session-card.jsx
@@ -43,20 +43,6 @@ function getETAFromTicks(ticks) {
   return eta.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function convertBitrate(bitrate) {
-  if (!bitrate) {
-    return "N/A";
-  }
-  const kbps = (bitrate / 1000).toFixed(1);
-  const mbps = (bitrate / 1000000).toFixed(1);
-
-  if (kbps >= 1000) {
-    return mbps + " Mbps";
-  } else {
-    return kbps + " Kbps";
-  }
-}
-
 function SessionCard(props) {
   const cardStyle = {
     backgroundImage: `url(proxy/Items/Images/Backdrop?id=${
@@ -137,24 +123,10 @@ function SessionCard(props) {
                     </Row>
                     <Row className="d-flex flex-column flex-md-row">
                       <Col className="col-auto ellipse">
-                        {props.data.session.PlayState.PlayMethod +
-                          (props.data.session.NowPlayingItem.MediaStreams
-                            ? " ( " +
-                              props.data.session.NowPlayingItem.MediaStreams.find(
-                                (stream) => stream.Type === "Video"
-                              )?.Codec.toUpperCase() +
-                              (props.data.session.TranscodingInfo
-                                ? " - " + props.data.session.TranscodingInfo.VideoCodec.toUpperCase()
-                                : "") +
-                              " - " +
-                              convertBitrate(
-                                props.data.session.TranscodingInfo
-                                  ? props.data.session.TranscodingInfo.Bitrate
-                                  : props.data.session.NowPlayingItem.MediaStreams.find((stream) => stream.Type === "Video")
-                                      ?.BitRate
-                              ) +
-                              " )"
-                            : "")}
+                        <span>{props.data.session.NowPlayingItem.VideoStream}</span>
+                      </Col>
+                      <Col className="col-auto ellipse">
+                        <span>{props.data.session.NowPlayingItem.AudioStream}</span>
                       </Col>
                       <Col className="col-auto ellipse">
                         <Tooltip title={props.data.session.NowPlayingItem.SubtitleStream}>


### PR DESCRIPTION
Not sure if you mind people contributing like this. I had fixed it on my branch an noticed a request was made for it.

Issue 
https://github.com/CyferShepard/Jellystat/issues/132

I based this on the SubtitleStream building and used the IsVideoDirect and IsAudioDirect flags to do this. I separated the Video and Audio into two different columns. I tried to keep the format the same as you had it. I am kind of new to Javascript (C++ is my main language) so I am not sure if the code is up to standards or not.

![JellyStatDirectAudioTranscodeVideo](https://github.com/user-attachments/assets/8fe65df7-ab44-456f-bf94-c9ce24eaccee)
![JellyStatDirectAudioVideo](https://github.com/user-attachments/assets/9c9cc484-18d8-4520-ba98-0d48d57a6a4f)
![JellyStatDirectVideoTranscodeAudio](https://github.com/user-attachments/assets/2ba3d38d-f921-41cf-90ee-801e257dcaca)
![JellyStatTranscodeAudioAndVideo](https://github.com/user-attachments/assets/2761fba4-6309-4282-8ed2-e1155632e4c9)

Thanks again!
