### PR TITLE
Added a resultLimit to getHistory and getLibraryHistory

### DIFF
--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -1928,6 +1928,11 @@
             "name": "page",
             "in": "query",
             "type": "string"
+          },
+          {
+            "name": "resultLimit",
+            "in": "query",
+            "type": "string"
           }
         ],
         "responses": {
@@ -1973,6 +1978,11 @@
           },
           {
             "name": "page",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "resultLimit",
             "in": "query",
             "type": "string"
           },


### PR DESCRIPTION
Added a resultLimit to getHistory and getLibraryHistory that defaults to the query size if not defined.

Just an FYI with the current size and page query on the Activity Page you could say display 10 items but see less if the case I describe below. I only see 9 results because one of my entries has the plus active.

Problem:
If a user started and stopped a movie 10 times and a user requests a size of 10 the return value would only be one entry since those items get grouped. 

Solution:
Add requestLimit (not sure if you want camel case in the query but was trying to make it more verbose) to the query. Now you can set the size to 50 and limit the grouped results to 10. Default requestLimit to size if not defined so that you would at least get all the results from the size attribute.

If you think this is making this too complicated I understand and feel free to close this merge request. I could do basically the same thing in my application using the existing api.