### PR TITLE
Clean up audio session card & Add translations for sessions

### DIFF
--- a/public/locales/en-UK/translation.json
+++ b/public/locales/en-UK/translation.json
@@ -17,7 +17,9 @@
     "LIBRARY_OVERVIEW": "Library Overview"
   },
   "SESSIONS": {
-    "NO_SESSIONS": "No Active Sessions Found"
+    "NO_SESSIONS": "No Active Sessions Found",
+    "DIRECT_PLAY": "Direct Play",
+    "TRANSCODE": "Transcode"
   },
   "STAT_CARDS": {
     "MOST_VIEWED_MOVIES": "MOST VIEWED MOVIES",
@@ -301,5 +303,6 @@
   "LONGITUDE": "Longitude",
   "TIMEZONE": "Timezone",
   "POSTCODE": "Postcode",
-  "X_ROWS_SELECTED": "{ROWS} Rows Selected"
+  "X_ROWS_SELECTED": "{ROWS} Rows Selected",
+  "SUBTITLES": "Subtitles"
 }

--- a/public/locales/fr-FR/translation.json
+++ b/public/locales/fr-FR/translation.json
@@ -17,7 +17,9 @@
     "LIBRARY_OVERVIEW": "Vue d'ensemble des médiathèques"
   },
   "SESSIONS": {
-    "NO_SESSIONS": "Aucune lecture en cours n'a été trouvée"
+    "NO_SESSIONS": "Aucune lecture en cours n'a été trouvée",
+    "DIRECT_PLAY": "",
+    "TRANSCODE": ""
   },
   "STAT_CARDS": {
     "MOST_VIEWED_MOVIES": "FILMS LES PLUS VUS",
@@ -301,5 +303,6 @@
   "LONGITUDE": "Longitude",
   "TIMEZONE": "Fuseau horaire",
   "POSTCODE": "Code postal",
-  "X_ROWS_SELECTED": "{ROWS} Ligne(s) sélectionnée(s)"
+  "X_ROWS_SELECTED": "{ROWS} Ligne(s) sélectionnée(s)",
+  "SUBTITLES": ""
 }

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -17,7 +17,9 @@
     "LIBRARY_OVERVIEW": "媒体库总览"
   },
   "SESSIONS": {
-    "NO_SESSIONS": "未找到活动会话"
+    "NO_SESSIONS": "未找到活动会话",
+    "DIRECT_PLAY": "",
+    "TRANSCODE": ""
   },
   "STAT_CARDS": {
     "MOST_VIEWED_MOVIES": "最多观看电影",
@@ -301,5 +303,6 @@
   "LONGITUDE": "经度",
   "TIMEZONE": "时区",
   "POSTCODE": "邮编",
-  "X_ROWS_SELECTED": "已选中 {ROWS} 行"
+  "X_ROWS_SELECTED": "已选中 {ROWS} 行",
+  "SUBTITLES": ""
 }

--- a/src/pages/components/sessions/session-card.jsx
+++ b/src/pages/components/sessions/session-card.jsx
@@ -122,16 +122,22 @@ function SessionCard(props) {
                       </Col>
                     </Row>
                     <Row className="d-flex flex-column flex-md-row">
+                      {props.data.session.NowPlayingItem.VideoStream !== "" &&
+                        <Col className="col-auto ellipse">
+                            <span>{props.data.session.NowPlayingItem.VideoStream}</span>
+                        </Col>
+                      }
                       <Col className="col-auto ellipse">
-                        <span>{props.data.session.NowPlayingItem.VideoStream}</span>
+                        {props.data.session.NowPlayingItem.AudioStream !== "" &&
+                          <span>{props.data.session.NowPlayingItem.AudioStream}</span>
+                        }
                       </Col>
                       <Col className="col-auto ellipse">
-                        <span>{props.data.session.NowPlayingItem.AudioStream}</span>
-                      </Col>
-                      <Col className="col-auto ellipse">
-                        <Tooltip title={props.data.session.NowPlayingItem.SubtitleStream}>
-                          <span>{props.data.session.NowPlayingItem.SubtitleStream}</span>
-                        </Tooltip>
+                        {props.data.session.NowPlayingItem.SubtitleStream !== "" &&
+                          <Tooltip title={props.data.session.NowPlayingItem.SubtitleStream}>
+                            <span>{props.data.session.NowPlayingItem.SubtitleStream}</span>
+                          </Tooltip>
+                        }
                       </Col>
                     </Row>
                     <Row>
@@ -185,7 +191,14 @@ function SessionCard(props) {
                         </Link>
                       </Card.Text>
                     </Row>
-                  ) : (
+                  ) : (props.data.session.NowPlayingItem.Type === "Audio" && props.data.session.NowPlayingItem.Artists.length > 0) ? (
+                    <Col className="col-auto p-0">
+                      <Card.Text>
+                        {props.data.session.NowPlayingItem.Artists[0]}
+                      </Card.Text>
+                    </Col>
+                  ) :
+                  (
                     <></>
                   )}
                   <Row className="d-flex flex-row justify-content-between p-0 m-0">

--- a/src/pages/components/sessions/sessions.jsx
+++ b/src/pages/components/sessions/sessions.jsx
@@ -9,6 +9,7 @@ import SessionCard from "./session-card";
 
 import Loading from "../general/loading";
 import { Trans } from "react-i18next";
+import i18next from "i18next";
 import socket from "../../../socket";
 
 function convertBitrate(bitrate) {
@@ -62,10 +63,11 @@ function Sessions() {
       return "";
     }
 
-    let transcodeType = "Direct Stream";
+    
+    let transcodeType = i18next.t("SESSIONS.DIRECT_PLAY");
     let transcodeVideoCodec = "";
     if (row.TranscodingInfo && !row.TranscodingInfo.IsVideoDirect){
-      transcodeType = "Transcode";
+      transcodeType = i18next.t("SESSIONS.TRANSCODE");
       transcodeVideoCodec = ` -> ${row.TranscodingInfo.VideoCodec.toUpperCase()}`;
     }
     let bitRate = convertBitrate(
@@ -75,7 +77,7 @@ function Sessions() {
 
     const originalVideoCodec = videoStream.Codec.toUpperCase();
     
-    return `Video: ${transcodeType} (${originalVideoCodec}${transcodeVideoCodec} - ${bitRate})`;
+    return `${i18next.t("VIDEO")}: ${transcodeType} (${originalVideoCodec}${transcodeVideoCodec} - ${bitRate})`;
   }
 
   const getAudioStream = (row) => {
@@ -85,10 +87,10 @@ function Sessions() {
       return "";
     }
 
-    let transcodeType = "Direct Stream";
+    let transcodeType = i18next.t("SESSIONS.DIRECT_PLAY");
     let transcodeCodec = "";
     if (row.TranscodingInfo && !row.TranscodingInfo.IsAudioDirect){
-      transcodeType = "Transcode";
+      transcodeType = i18next.t("SESSIONS.TRANSCODE");
       transcodeCodec = ` -> ${row.TranscodingInfo.AudioCodec.toUpperCase()}`;
     }
 
@@ -109,8 +111,8 @@ function Sessions() {
         originalCodec = row.NowPlayingItem.MediaStreams[streamIndex].Codec.toUpperCase();
     }
 
-    return originalCodec != "" ? `Audio: ${transcodeType} (${originalCodec}${transcodeCodec}${bitRate})`
-                               : `Audio: ${transcodeType}`;
+    return originalCodec != "" ? `${i18next.t("AUDIO")}: ${transcodeType} (${originalCodec}${transcodeCodec}${bitRate})`
+                               : `${i18next.t("AUDIO")}: ${transcodeType}`;
   }
 
   const getSubtitleStream = (row) => {
@@ -127,7 +129,7 @@ function Sessions() {
     }
 
     if (row.NowPlayingItem.MediaStreams && row.NowPlayingItem.MediaStreams.length) {
-      result = `Subtitles: ${row.NowPlayingItem.MediaStreams[subStreamIndex].DisplayTitle}`;
+      result = `${i18next.t("SUBTITLES")}: ${row.NowPlayingItem.MediaStreams[subStreamIndex].DisplayTitle}`;
     }
 
     return result;

--- a/src/pages/components/sessions/sessions.jsx
+++ b/src/pages/components/sessions/sessions.jsx
@@ -79,11 +79,10 @@ function Sessions() {
   }
 
   const getAudioStream = (row) => {
-    let result = "";
-
+    let mediaTypeAudio = row.NowPlayingItem.Type === 'Audio';
     let streamIndex = row.PlayState.AudioStreamIndex;
-    if (streamIndex === undefined || streamIndex === -1) {
-      return result;
+    if ((streamIndex === undefined || streamIndex === -1) && !mediaTypeAudio) {
+      return "";
     }
 
     let transcodeType = "Direct Stream";
@@ -93,12 +92,24 @@ function Sessions() {
       transcodeCodec = ` -> ${row.TranscodingInfo.AudioCodec.toUpperCase()}`;
     }
 
-    let originalCodec = "";
-    if (row.NowPlayingItem.MediaStreams && row.NowPlayingItem.MediaStreams.length && streamIndex < row.NowPlayingItem.MediaStreams.length) {
-      originalCodec = row.NowPlayingItem.MediaStreams[streamIndex].Codec.toUpperCase();
+    let bitRate = "";
+    if (mediaTypeAudio) {
+      bitRate = " - " + convertBitrate(
+        row.TranscodingInfo
+          ? row.TranscodingInfo.Bitrate
+          : row.NowPlayingItem.Bitrate);
     }
 
-    return originalCodec != "" ? `Audio: ${transcodeType} (${originalCodec}${transcodeCodec})`
+    let originalCodec = "";
+    if (mediaTypeAudio){
+      
+      originalCodec = `${row.NowPlayingItem.Container.toUpperCase()}`;
+    }
+    else if (row.NowPlayingItem.MediaStreams && row.NowPlayingItem.MediaStreams.length && streamIndex < row.NowPlayingItem.MediaStreams.length) {
+        originalCodec = row.NowPlayingItem.MediaStreams[streamIndex].Codec.toUpperCase();
+    }
+
+    return originalCodec != "" ? `Audio: ${transcodeType} (${originalCodec}${transcodeCodec}${bitRate})`
                                : `Audio: ${transcodeType}`;
   }
 


### PR DESCRIPTION
Sorry to keep hitting you with merge requests.

I noticed when playing audio the sessions card could be updated.

Stable branch card
![jellyStatCurrentAudioSessionCard](https://github.com/user-attachments/assets/30f4150c-288c-4898-a851-f24d32afc7b2)

I modified it to look like the video line with bitrate.
I also added Artist above the song title (I could remove this if it was a decision to leave this off)
![jellyStatAudioArtistNameAudioLine](https://github.com/user-attachments/assets/c5e77d15-2825-4f06-9f2f-2c3f1e083904)

I didn't realize there was a translation table on my last merge request and had some hardcoded strings that I put in the table. I was not sure if a script ran to fill in the translations for other languages or if I needed to do that.
