### PR TITLE
Fix NaN showing up for audio only activity

### DIFF
--- a/src/pages/components/activity/stream_info.jsx
+++ b/src/pages/components/activity/stream_info.jsx
@@ -90,8 +90,8 @@ function Row(logs) {
 
         <TableRow>
           <TableCell className="py-0 pb-1" ><Trans i18nKey={"FRAMERATE"}/></TableCell>
-          <TableCell className="py-0 pb-1" >{data.MediaStreams ? parseFloat(data.MediaStreams.find(stream => stream.Type === 'Video')?.RealFrameRate).toFixed(2) : '-'}</TableCell>
-          <TableCell className="py-0 pb-1" >{data.MediaStreams ? parseFloat(data.MediaStreams.find(stream => stream.Type === 'Video')?.RealFrameRate).toFixed(2) : '-'}</TableCell>
+          <TableCell className="py-0 pb-1" >{data.MediaStreams ? data.MediaStreams.find(stream => stream.Type === 'Video') ? parseFloat(data.MediaStreams.find(stream => stream.Type === 'Video').RealFrameRate.toFixed(2)) : '-' : '-'}</TableCell>
+          <TableCell className="py-0 pb-1" >{data.MediaStreams ? data.MediaStreams.find(stream => stream.Type === 'Video') ? parseFloat(data.MediaStreams.find(stream => stream.Type === 'Video').RealFrameRate.toFixed(2)) : '-' : '-'}</TableCell>
         </TableRow>
 
         <TableRow>


### PR DESCRIPTION
Not sure if there is a better way of doing this. 

Problem: 
NaN gets displayed for audio only streams since it ends up doing a parseFloat on a '-' character
![JellyStatAudioNaN](https://github.com/user-attachments/assets/f342af78-984a-4bf5-b3fc-1b40f038ae12)

After Fix:
![JellyStatAudioNaN_AfterFix](https://github.com/user-attachments/assets/405a45eb-043a-4bf0-82f2-741c390046e9)
