### PR TITLE
Update security.jsx

### DIFF
--- a/src/pages/components/settings/security.jsx
+++ b/src/pages/components/settings/security.jsx
@@ -95,11 +95,6 @@ export default function SettingsConfig() {
   async function handleFormSubmit(event) {
     event.preventDefault();
     setisSubmitted("");
-    if (formValues.JS_C_PASSWORD) {
-      setisSubmitted("Failed");
-      setsubmissionMessage(i18next.t("ERROR_MESSAGES.PASSWORD_LENGTH"));
-      return;
-    }
 
     if (
       (formValues.JS_C_PASSWORD && !formValues.JS_PASSWORD) ||


### PR DESCRIPTION
Sorry this is my first pull request ever on Github, so please bear with me and kindly point me in the right direction if I did anything wrong.

Removed a check that evaluated for any input in the Current Password field and would cause the entry to enter in any non-null input to fail due to password length.  This is related to: https://github.com/CyferShepard/Jellystat/issues/254