### PR TITLE
Emby Stream Type Fix and added IS_EMBY_API to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 | JS_GEOLITE_ACCOUNT_ID               | `null`   | `123456`                        | maxmind.com user id to be used for Geolocating IP Addresses (Can be found at https://www.maxmind.com/en/accounts/current/edit)           |
 | JS_GEOLITE_LICENSE_KEY              | `null`   | `ASDWdaSdawe2sd186`             | License key you need to generate on maxmind to use their services                                                                        |
 | MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK | `1`      | `10`                            | The minimum time (in seconds) to include a playback record, which can be used to exclude short playbacks                                 |
+| IS_EMBY_API                         | `false`  | `true`                          | Set to true if using Emby instead of Jellyfin                                                                                            |
 
 ## Getting Started with Development
 

--- a/public/locales/ca-ES/translation.json
+++ b/public/locales/ca-ES/translation.json
@@ -289,6 +289,7 @@
   "SOURCE_DETAILS": "Detalls de la font",
   "DIRECT": "Directe",
   "TRANSCODE": "Transcodificar",
+  "DIRECT_STREAM": "",
   "USERNAME": "Nom d'usuari",
   "PASSWORD": "Contrasenya",
   "LOGIN": "Iniciar sessió",

--- a/public/locales/en-UK/translation.json
+++ b/public/locales/en-UK/translation.json
@@ -289,6 +289,7 @@
   "SOURCE_DETAILS": "Source Details",
   "DIRECT": "Direct",
   "TRANSCODE": "Transcode",
+  "DIRECT_STREAM": "Direct Stream",
   "USERNAME": "Username",
   "PASSWORD": "Password",
   "LOGIN": "Login",

--- a/public/locales/fr-FR/translation.json
+++ b/public/locales/fr-FR/translation.json
@@ -283,6 +283,7 @@
   "SOURCE_DETAILS": "Détails de la source",
   "DIRECT": "Direct",
   "TRANSCODE": "Transcodage",
+  "DIRECT_STREAM": "",
   "USERNAME": "Nom d'utilisateur",
   "PASSWORD": "Mot de passe",
   "LOGIN": "Connexion",

--- a/public/locales/it-IT/translation.json
+++ b/public/locales/it-IT/translation.json
@@ -281,6 +281,7 @@
   "SOURCE_DETAILS": "Dettagli sorgente",
   "DIRECT": "Diretto",
   "TRANSCODE": "Transcodifica",
+  "DIRECT_STREAM": "",
   "USERNAME": "Nome utente",
   "PASSWORD": "Password",
   "LOGIN": "Accedi",

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -283,6 +283,7 @@
   "SOURCE_DETAILS": "媒体源信息",
   "DIRECT": "直接播放",
   "TRANSCODE": "转码",
+  "DIRECT_STREAM": "",
   "USERNAME": "用户名",
   "PASSWORD": "密码",
   "LOGIN": "登录",

--- a/src/pages/components/statCards/playback_method_stats.jsx
+++ b/src/pages/components/statCards/playback_method_stats.jsx
@@ -10,7 +10,8 @@ import BarChartGroupedLineIcon from "remixicon-react/BarChartGroupedLineIcon";
 function PlaybackMethodStats(props) {
   const translations = {
     DirectPlay: <Trans i18nKey="DIRECT" />,
-    Transocde: <Trans i18nKey="TRANSCODE" />,
+    Transcode: <Trans i18nKey="TRANSCODE" />,
+    DirectStream: <Trans i18nKey="DIRECT_STREAM" />,
   };
   const chartIcon = <BarChartGroupedLineIcon size={"100%"} />;
 
@@ -79,7 +80,7 @@ function PlaybackMethodStats(props) {
     <ItemStatComponent
       base_url={config.settings?.EXTERNAL_URL ?? config.hostUrl}
       data={data.map((stream) =>
-        stream.Name == "DirectPlay" ? { ...stream, Name: translations.DirectPlay } : { ...stream, Name: translations.Transocde }
+        stream.Name == "DirectPlay" ? { ...stream, Name: translations.DirectPlay } : stream.Name == "DirectStream" ? { ...stream, Name: translations.DirectStream } : { ...stream, Name: translations.Transcode }
       )}
       icon={chartIcon}
       heading={<Trans i18nKey="STAT_CARDS.CONCURRENT_STREAMS" />}


### PR DESCRIPTION
Emby has another stream type of Direct Stream. Added this to the types. I also added the IS_EMBY_API to the readme. Not sure if you wanted this or not.

Transcode is the default so it would show up twice.

Old
![JellystatConcurrentEmbyOriginal](https://github.com/user-attachments/assets/158c4d81-d377-4704-b93f-21a1ea649441)

Update
![JellystatConcurrentEmbyFix](https://github.com/user-attachments/assets/965e58c8-1e3d-481a-96bd-df3aa6154cbe)
