### PR TITLE
Add plural to timeline episode count

### DIFF
--- a/public/locales/en-UK/translation.json
+++ b/public/locales/en-UK/translation.json
@@ -234,7 +234,8 @@
   },
   "TIMELINE_PAGE": {
     "TIMELINE": "Timeline",
-    "EPISODES":"Episodes"
+    "EPISODES_one":"Episode",
+    "EPISODES_other":"Episodes"
   },
   "SEARCH": "Search",
   "TOTAL": "Total",

--- a/src/pages/components/activity-timeline/activity-timeline-item.jsx
+++ b/src/pages/components/activity-timeline/activity-timeline-item.jsx
@@ -76,7 +76,8 @@ const TimeLineTextContent = (props) => {
       </Typography>
       {MediaType === MEDIA_TYPES.Shows && EpisodeCount && (
         <Typography>
-          {EpisodeCount} <Trans i18nKey="TIMELINE_PAGE.EPISODES" />
+          {EpisodeCount}{" "}
+          <Trans i18nKey="TIMELINE_PAGE.EPISODES" count={+EpisodeCount} />
         </Typography>
       )}
     </div>


### PR DESCRIPTION
One more small fix I noticed. 
Add plurality to the "Episodes" Text in the timeline.