### PR TITLE
allow configuring LISTEN_IP/enable IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 | POSTGRES_PASSWORD `REQUIRED`        | `null`   | `postgres`                      | Password that will be used in postgres database                                                                                          |
 | POSTGRES_IP `REQUIRED`              | `null`   | `jellystat-db` or `192.168.0.5` | Hostname/IP of postgres instance                                                                                                         |
 | POSTGRES_PORT `REQUIRED`            | `null`   | `5432`                          | Port Postgres is running on                                                                                                              |
+| JS_LISTEN_IP                        | `0.0.0.0`| `0.0.0.0` or `::`               | Enable listening on specific IP or `::` for IPv6 |
 | JWT_SECRET `REQUIRED`               | `null`   | `my-secret-jwt-key`             | JWT Key to be used to encrypt JWT tokens for authentication                                                                              |
 | TZ `REQUIRED`                       | `null`   | `Etc/UTC`                       | Server timezone (Can be found at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)                                      |
 | JS_BASE_URL                         | `/`      | `/`                             | Base url                                                                                                                                 |

--- a/backend/server.js
+++ b/backend/server.js
@@ -53,7 +53,7 @@ const ensureSlashes = (url) => {
 };
 
 const PORT = 3000;
-const LISTEN_IP = "0.0.0.0";
+const LISTEN_IP = process.env.JS_LISTEN_IP || "0.0.0.0";
 const JWT_SECRET = process.env.JWT_SECRET;
 const BASE_NAME = process.env.JS_BASE_URL ? ensureSlashes(process.env.JS_BASE_URL) : "";
 
@@ -239,7 +239,7 @@ try {
 
       setupWebSocketServer(server, BASE_NAME);
       server.listen(PORT, LISTEN_IP, async () => {
-        console.log(`[JELLYSTAT] Server listening on http://127.0.0.1:${PORT}`);
+        console.log(`[JELLYSTAT] Server listening on http://${LISTEN_IP}:${PORT}`);
         ActivityMonitor.ActivityMonitor(1000);
         new TaskManager();
         new TaskScheduler();


### PR DESCRIPTION
This PR allows configuring the LISTEN_IP value, making it possible to bind the server to an IPv6-compatible address (e.g., ::). To maintain backward compatibility, the default remains 0.0.0.0.