### PR TITLE
Allow defining PORT and LISTEN_IP environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@
 | JS_PASSWORD                         | `null`   | `Password`                      | Master Override Password in case username or password used during setup is forgotten (Both `JS_USER` and `JS_PASSWORD` required to work) |
 | POSTGRES_DB                         | `jfstat` | `jfstat`                        | Name of postgres database                                                                                                                |
 | REJECT_SELF_SIGNED_CERTIFICATES     | `true`   | `false`                         | Allow or deny self signed SSL certificates                                                                                               |
-| JS_GEOLITE_ACCOUNT_ID               | `null`   | `123456`                        | maxmind.com user id to be used for Geolocating IP Addresses (Can be found at https://www.maxmind.com/en/accounts/current/edit)           |
+| JS_GEOLITE_ACCOUNT_ID               | `null`   | `123456`                        | maxmind.com user id to be used for Geolocating IP Addresses (Can be found at https://www.maxmind.com/en/accounts/current/edit)    |
 | JS_GEOLITE_LICENSE_KEY              | `null`   | `ASDWdaSdawe2sd186`             | License key you need to generate on maxmind to use their services                                                                        |
 | MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK | `1`      | `10`                            | The minimum time (in seconds) to include a playback record, which can be used to exclude short playbacks                                 |
+| PORT                                | `3000`   | `3001`                          | The port used by Jellystat                                                                                                               |
 
 ## Getting Started with Development
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@
 | JS_GEOLITE_ACCOUNT_ID               | `null`   | `123456`                        | maxmind.com user id to be used for Geolocating IP Addresses (Can be found at https://www.maxmind.com/en/accounts/current/edit)    |
 | JS_GEOLITE_LICENSE_KEY              | `null`   | `ASDWdaSdawe2sd186`             | License key you need to generate on maxmind to use their services                                                                        |
 | MINIMUM_SECONDS_TO_INCLUDE_PLAYBACK | `1`      | `10`                            | The minimum time (in seconds) to include a playback record, which can be used to exclude short playbacks                                 |
-| PORT                                | `3000`   | `3001`                          | The port used by Jellystat                                                                                                               |
+| LISTEN_IP                           | `0.0.0.0`| `127.0.0.1`                     | Bind address                                                                                                                             |
+| PORT                                | `3000`   | `3001`                          | Port                                                                                                                                     |
 
 ## Getting Started with Development
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,4 +9,5 @@ JWT_SECRET = # ultra secret word
 JS_GEOLITE_ACCOUNT_ID = # optional, your GeoLite account ID to show geolocation info for client IPs
 JS_GEOLITE_LICENSE_KEY = # optional, your GeoLite account license key to show geolocation info for client IPs
 
+LISTEN_IP = # your bind address
 PORT = # your jellystat port

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,3 +8,5 @@ JWT_SECRET = # ultra secret word
 
 JS_GEOLITE_ACCOUNT_ID = # optional, your GeoLite account ID to show geolocation info for client IPs
 JS_GEOLITE_LICENSE_KEY = # optional, your GeoLite account license key to show geolocation info for client IPs
+
+PORT = # your jellystat port

--- a/backend/create_database.js
+++ b/backend/create_database.js
@@ -16,7 +16,7 @@ const client = new Client({
 const createDatabase = async () => {
   try {
     await client.connect(); // gets connection
-    await client.query(CREATE DATABASE IF NOT EXIST _POSTGRES_DATABASE); // sends queries
+    await client.query('CREATE DATABASE ' + _POSTGRES_DATABASE); // sends queries
     return true;
   } catch (error) {
     if (!error.stack.includes('already exists')) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -50,8 +50,8 @@ const ensureSlashes = (url) => {
   return url;
 };
 
-const PORT = process.env.PORT;
-const LISTEN_IP = "0.0.0.0";
+const PORT = process.env.PORT || 3000;
+const LISTEN_IP = process.env.LISTEN_IP || "0.0.0.0";
 const JWT_SECRET = process.env.JWT_SECRET;
 const BASE_NAME = process.env.JS_BASE_URL ? ensureSlashes(process.env.JS_BASE_URL) : "";
 


### PR DESCRIPTION
### What needs to be done
- Define `PORT` and `LISTEN_IP` in environment variables for later use
- Use `process.env.<var>` to grab `PORT` and `LISTEN_IP` vars from `.env`

### What has been done
- Added `PORT` and `LISTEN_IP` in `.env.example` file
- Added variables to README
- Added `process.env.PORT` and `process.env.LISTEN_IP` instead of hardcoded values. If the variables are not set, we use defaults.

Greatly helps with automation situations on bare metal, since otherwise you need to edit the file manually (or automate the manual editing process) in order to have the service listen on a different port/ip. An option is to use a reverse proxy to work around it, but that doesn't solve the main concern here.

Please do verify changes, I am no professional in terms of coding and programming, I just package apps and edit code from time to time.

### Suggestions for further improvement that I would like to implement
- Implement ability to not fail if database is already created. Instead, either re-create db or use existing if valid. For instance, instead of using ```await client.query(`CREATE DATABASE ' \\+ _POSTGRES_DATABASE`);```, we could use something like `SELECT 'CREATE DATABASE <db>' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '<db>')`. This is just an idea if anyone proceeds with this.
- Implement ability to pre-create user and predefine Jellyfin values. As it is now, automating is difficult because instead of defining this in `.env` file, you have to proceed with the following `curl` requests to hack the process:
```
# Create admin user
API_TOKEN_RESPONSE=$(curl --silent --show-error --fail -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
API_TOKEN=$(echo "$API_TOKEN_RESPONSE" | jq -r '.token')

# Create and save API_KEY
API_KEY_RESPONSE=$(curl --silent --show-error --fail -X POST http://127.0.0.1:$port/api/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "$name"}')
API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')

##############################################################
# some further steps for the Jellyfin fields might be required
##############################################################

# Verify if setup stage has incremented
setup_state_response=$(curl --silent --show-error --fail -X GET http://127.0.0.1:$port/auth/isConfigured -H "Content-Type: application/json")
```