### PR TITLE
refactor: Use GET in `/statistics` API endpoints instead of POST

### DIFF
--- a/backend/routes/stats.js
+++ b/backend/routes/stats.js
@@ -407,9 +407,9 @@ router.post("/getLibraryLastPlayed", async (req, res) => {
   }
 });
 
-router.post("/getViewsOverTime", async (req, res) => {
+router.get("/getViewsOverTime", async (req, res) => {
   try {
-    const { days } = req.body;
+    const { days } = req.query;
     let _days = days;
     if (days === undefined) {
       _days = 30;
@@ -446,9 +446,9 @@ router.post("/getViewsOverTime", async (req, res) => {
   }
 });
 
-router.post("/getViewsByDays", async (req, res) => {
+router.get("/getViewsByDays", async (req, res) => {
   try {
-    const { days } = req.body;
+    const { days } = req.query;
     let _days = days;
     if (days === undefined) {
       _days = 30;
@@ -481,9 +481,9 @@ router.post("/getViewsByDays", async (req, res) => {
   }
 });
 
-router.post("/getViewsByHour", async (req, res) => {
+router.get("/getViewsByHour", async (req, res) => {
   try {
-    const { days } = req.body;
+    const { days } = req.query;
     let _days = days;
     if (days === undefined) {
       _days = 30;

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -3504,7 +3504,7 @@
       }
     },
     "/stats/getViewsOverTime": {
-      "post": {
+      "get": {
         "tags": [
           "Stats"
         ],
@@ -3526,16 +3526,9 @@
             "type": "string"
           },
           {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "days": {
-                  "example": "any"
-                }
-              }
-            }
+            "name": "days",
+            "in": "query",
+            "type": "string"
           }
         ],
         "responses": {
@@ -3558,7 +3551,7 @@
       }
     },
     "/stats/getViewsByDays": {
-      "post": {
+      "get": {
         "tags": [
           "Stats"
         ],
@@ -3580,16 +3573,9 @@
             "type": "string"
           },
           {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "days": {
-                  "example": "any"
-                }
-              }
-            }
+            "name": "days",
+            "in": "query",
+            "type": "string"
           }
         ],
         "responses": {
@@ -3612,7 +3598,7 @@
       }
     },
     "/stats/getViewsByHour": {
-      "post": {
+      "get": {
         "tags": [
           "Stats"
         ],
@@ -3634,16 +3620,9 @@
             "type": "string"
           },
           {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "days": {
-                  "example": "any"
-                }
-              }
-            }
+            "name": "days",
+            "in": "query",
+            "type": "string"
           }
         ],
         "responses": {

--- a/src/pages/components/statistics/daily-play-count.jsx
+++ b/src/pages/components/statistics/daily-play-count.jsx
@@ -17,12 +17,11 @@ function DailyPlayStats(props) {
   
   useEffect(() => {
     const fetchLibraries = () => {
-      const url = `/stats/getViewsOverTime`;
+      const url = `/stats/getViewsOverTime?days=${props.days}`;
 
       axios
-        .post(
+        .get(
           url,
-          { days: props.days },
           {
             headers: {
               Authorization: `Bearer ${token}`,

--- a/src/pages/components/statistics/play-stats-by-day.jsx
+++ b/src/pages/components/statistics/play-stats-by-day.jsx
@@ -13,12 +13,11 @@ function PlayStatsByDay(props) {
 
   useEffect(() => {
     const fetchLibraries = () => {
-      const url = `/stats/getViewsByDays`;
+      const url = `/stats/getViewsByDays?days=${props.days}`;
 
       axios
-        .post(
+        .get(
           url,
-          { days: props.days },
           {
             headers: {
               Authorization: `Bearer ${token}`,

--- a/src/pages/components/statistics/play-stats-by-hour.jsx
+++ b/src/pages/components/statistics/play-stats-by-hour.jsx
@@ -12,12 +12,11 @@ function PlayStatsByHour(props) {
 
   useEffect(() => {
     const fetchLibraries = () => {
-      const url = `/stats/getViewsByHour`;
+      const url = `/stats/getViewsByHour?days=${props.days}`;
 
       axios
-        .post(
+        .get(
           url,
-          { days: props.days },
           {
             headers: {
               Authorization: `Bearer ${token}`,


### PR DESCRIPTION
`POST` is usually indicates that data is being inserted or updated, but that's not the case here.

This is a very minor change and doesn't seem to break anything.