### PR TITLE
Session card 12/24 time update and minor fix

### DIFF
--- a/src/pages/components/sessions/session-card.jsx
+++ b/src/pages/components/sessions/session-card.jsx
@@ -39,9 +39,10 @@ function getETAFromTicks(ticks) {
   // Calculate ETA
   const etaMillis = currentDate + ticks / 10000;
   const eta = new Date(etaMillis);
+  const twelve_hr = JSON.parse(localStorage.getItem("12hr"));
 
   // Return formated string in user locale
-  return eta.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return eta.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: twelve_hr });
 }
 
 function SessionCard(props) {

--- a/src/pages/components/sessions/sessions.jsx
+++ b/src/pages/components/sessions/sessions.jsx
@@ -139,7 +139,7 @@ function Sessions() {
     let transcodeCodec = "";
     if (row.TranscodingInfo && !row.TranscodingInfo.IsAudioDirect) {
       transcodeType = i18next.t("SESSIONS.TRANSCODE");
-      transcodeCodec = ` -> ${row.TranscodingInfo.AudioCodec.toUpperCase()}-${row.TranscodingInfo.AudioChannels}Ch}`;
+      transcodeCodec = ` -> ${row.TranscodingInfo.AudioCodec.toUpperCase()}-${row.TranscodingInfo.AudioChannels}Ch`;
     }
 
     let originalCodec = "";


### PR DESCRIPTION
Used the default setting for 12 vs 24 hour to adjust the ETA time in the session card. I also removed an unnecessary bracket that I left in the audio stream.