### PR TITLE
Session card title overflow

### DIFF
--- a/src/pages/components/sessions/session-card.jsx
+++ b/src/pages/components/sessions/session-card.jsx
@@ -408,7 +408,7 @@ function SessionCard(props) {
               </Row>
             )}
           </Col>
-          <Col className="col-auto p-0">
+          <Col className="col-7 p-0">
             {props.data.session.NowPlayingItem.Type === "Episode" ? (
               <Row className="d-flex flex-row justify-content-start p-0">
                 <Card.Text>


### PR DESCRIPTION
Sorry one last problem I found originally on mobile. The Title a TV show that can get long was forcing the user and user picture down. I just restricted the title to col-7 to prevent this. When the card is larger is still allows for the entire title.

Original Issue
![Jellystat-UserMoved](https://github.com/user-attachments/assets/f5fe63fd-17c2-457d-a81c-2f5061c03d15)

With Fix
![Jellystat-TitleLimited](https://github.com/user-attachments/assets/bfcad342-50b0-4c62-bd5d-5c798ed67428)

![Jellystat-FullSizeCard](https://github.com/user-attachments/assets/6d50c31b-ed32-4f12-8f44-83439ede3160)


