### PR TITLE
Refactor Jellyfin authentication to use standard Authorization headers

### DIFF
--- a/backend/classes/jellyfin-api.js
+++ b/backend/classes/jellyfin-api.js
@@ -124,7 +124,7 @@ class JellyfinAPI {
 
       const response = await axios.get(url, {
         headers: {
-          "X-MediaBrowser-Token": this.config.JF_API_KEY,
+          "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
         },
       });
       if (Array.isArray(response?.data)) {
@@ -183,7 +183,7 @@ class JellyfinAPI {
       while (startIndex < total || total === undefined) {
         const response = await axios.get(url, {
           headers: {
-            "X-MediaBrowser-Token": this.config.JF_API_KEY,
+            "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
           },
           params: {
             fields: "MediaSources,DateCreated,Genres",
@@ -249,7 +249,7 @@ class JellyfinAPI {
       while (startIndex < total || total === undefined) {
         const response = await axios.get(url, {
           headers: {
-            "X-MediaBrowser-Token": this.config.JF_API_KEY,
+            "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
           },
           params: {
             fields: "MediaSources,DateCreated,Genres",
@@ -317,7 +317,7 @@ class JellyfinAPI {
 
       const response = await axios.get(url, {
         headers: {
-          "X-MediaBrowser-Token": this.config.JF_API_KEY,
+          "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
         },
       });
 
@@ -340,7 +340,7 @@ class JellyfinAPI {
 
       const response = await axios.get(url, {
         headers: {
-          "X-MediaBrowser-Token": this.config.JF_API_KEY,
+          "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
         },
       });
 
@@ -365,7 +365,7 @@ class JellyfinAPI {
     try {
       const response = await axios.get(url, {
         headers: {
-          "X-MediaBrowser-Token": this.config.JF_API_KEY,
+          "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
         },
       });
 
@@ -388,7 +388,7 @@ class JellyfinAPI {
 
       const response = await axios.get(url, {
         headers: {
-          "X-MediaBrowser-Token": this.config.JF_API_KEY,
+          "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
         },
       });
 
@@ -432,7 +432,7 @@ class JellyfinAPI {
 
       const response = await axios.get(url, {
         headers: {
-          "X-MediaBrowser-Token": this.config.JF_API_KEY,
+          "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
         },
         params: {
           fields: "MediaSources,DateCreated,Genres",
@@ -455,10 +455,8 @@ class JellyfinAPI {
     try {
       if (compareVersions(this.version, "10.11.0") >= 0) {
         const socketUrl =
-          (this.config.JF_EXTERNAL_HOST ?? this.config.JF_HOST).replace(/^http/, "ws").replace(/^https/, "wss") +
-          "/socket?api_key=" +
-          this.config.JF_API_KEY;
-        const sessionData = await getSessionData(socketUrl);
+          (this.config.JF_EXTERNAL_HOST ?? this.config.JF_HOST).replace(/^http/, "ws").replace(/^https/, "wss") + "/socket";
+        const sessionData = await getSessionData(socketUrl, this.config.JF_API_KEY);
         if (sessionData != null) {
           return sessionData;
         }
@@ -469,7 +467,7 @@ class JellyfinAPI {
       const response = await axios
         .get(url, {
           headers: {
-            "X-MediaBrowser-Token": this.config.JF_API_KEY,
+            "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
           },
         })
         .then((response) => {
@@ -515,7 +513,7 @@ class JellyfinAPI {
 
       const response = await axios.get(url, {
         headers: {
-          "X-MediaBrowser-Token": this.config.JF_API_KEY,
+          "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
         },
       });
       return response.data;
@@ -542,7 +540,7 @@ class JellyfinAPI {
         },
         {
           headers: {
-            "X-MediaBrowser-Token": this.config.JF_API_KEY,
+            "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
           },
         }
       );
@@ -583,7 +581,7 @@ class JellyfinAPI {
 
       const response = await axios.get(validation_url, {
         headers: {
-          "X-MediaBrowser-Token": apikey,
+          "Authorization": 'MediaBrowser Token="' + apikey + '"',
         },
       });
       result.isValid = response.status == 200;
@@ -610,7 +608,7 @@ class JellyfinAPI {
     try {
       const response = await axios.get(url, {
         headers: {
-          "X-MediaBrowser-Token": this.config.JF_API_KEY,
+          "Authorization": 'MediaBrowser Token="' + this.config.JF_API_KEY + '"',
         },
       });
       return response?.data || {};

--- a/backend/classes/sessions-socket-client.js
+++ b/backend/classes/sessions-socket-client.js
@@ -9,8 +9,15 @@ const reconnectInterval = 60000;
 let reconnectNextAttempt = null;
 let keepAliveInterval;
 
-function initializeClient(websocketUrl) {
-  wsClient = new WebSocketClient(websocketUrl);
+function initializeClient(websocketUrl, apiKey) {
+  const options = {
+    headers: {
+      "Authorization": 'MediaBrowser Token="' + apiKey + '"'
+    }
+  };
+  
+  wsClient = new WebSocketClient(websocketUrl, options);
+  
   wsClient.onOpen = () => {
     console.log(`[JELLYFIN-WEBSOCKET]: Connected to the server.`);
     errorCount = 0;
@@ -64,9 +71,9 @@ function initializeClient(websocketUrl) {
   };
 }
 
-async function connect(websocketUrl) {
+async function connect(websocketUrl, apiKey) {
   if (wsClient == null) {
-    initializeClient(websocketUrl);
+    initializeClient(websocketUrl, apiKey);
   }
   if (errorCount >= maxErrorCount) {
     const now = Date.now();
@@ -89,13 +96,13 @@ async function connect(websocketUrl) {
   await wsClient.connect();
 }
 
-async function getSessionData(websocketUrl) {
+async function getSessionData(websocketUrl, apikey) {
   if (wsClient == null || wsClient.getConnectionStatus() != "OPEN") {
     if (errorCount < maxErrorCount) {
       console.log(`[JELLYFIN-WEBSOCKET]: WebSocket not connected. Connecting... (Attempt ${errorCount + 1} of ${maxErrorCount})`);
     }
 
-    await connect(websocketUrl);
+    await connect(websocketUrl, apikey);
     if (errorCount < maxErrorCount) {
       if (wsClient.getConnectionStatus() != "OPEN") {
         console.log("[JELLYFIN-WEBSOCKET]: WebSocket connection failed.");

--- a/backend/classes/websocket-client.js
+++ b/backend/classes/websocket-client.js
@@ -1,16 +1,19 @@
 const WebSocket = require("ws");
 
 class WebSocketClient {
-  constructor(url) {
+  constructor(url, options) {
     this.url = url;
+	this.options = options || {};
     this.socket = null;
   }
 
   connect() {
     return new Promise((resolve, reject) => {
-      this.socket = new WebSocket(this.url, {
+	  const wsOptions = {
         rejectUnauthorized: (process.env.REJECT_SELF_SIGNED_CERTIFICATES || "true").toLowerCase() === "true",
-      });
+        ...this.options
+      };
+      this.socket = new WebSocket(this.url, wsOptions);
 
       this.socket.on("open", () => {
         // console.log("Connected to WebSocket server");


### PR DESCRIPTION
This PR refactors the authentication logic for both the REST API and WebSocket connections to align with modern Jellyfin standards. This addresses connectivity issues experienced on server configurations like (Docker behind Nginx) where i faced persistent 401 Unauthorized and 403 Forbidden errors.