### PR TITLE
Add source label to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Stage 1: Build the application
 FROM node:slim AS builder
+LABEL org.opencontainers.image.source="https://github.com/CyferShepard/Jellystat"
 
 WORKDIR /app
 


### PR DESCRIPTION
The source label in the Docker container helps the Renovate bot correctly fetch and show changelogs for new versions fetched from Docker Hub.
This is described here:
https://docs.renovatebot.com/modules/datasource/docker/#description

This is useful when using GitOps, as I do.