### PR TITLE
Honor base URL when making websocket connection from browser

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -1,8 +1,8 @@
 import { io } from "socket.io-client";
 import baseUrl from "./lib/baseurl";
 
-const socket = io(baseUrl, {
-  path: "/socket.io",
+const socket = io("/", {
+  path: baseUrl + "/socket.io",
   auth: {
     token: localStorage.getItem("token"),
   },


### PR DESCRIPTION
socket.io docs[1] say that path in URI represents namespace but actual path is provided via options.

Ref #488

[1] https://socket.io/docs/v4/client-options/#path

This change fixes listing of active sessions for me.