### PR TITLE
Add shutdown tasks and fix signal forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM node:22.21.1-bookworm-slim AS builder
+FROM node:22.21.1-alpine3.23 AS builder
 
 WORKDIR /app
 
@@ -14,13 +14,9 @@ COPY entry.sh ./
 RUN npm run build
 
 # Stage 2: Create the production image
-FROM node:22.21.1-bookworm-slim
+FROM node:22.21.1-alpine3.23
 
-RUN apt-get update && \
-    apt-get install -yqq --no-install-recommends wget && \
-    apt-get autoremove && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache wget
 
 WORKDIR /app
 
@@ -35,4 +31,5 @@ HEALTHCHECK --interval=30s \
 
 EXPOSE 3000
 
-CMD ["/entry.sh"]
+CMD ["npm", "run", "start"]
+ENTRYPOINT ["/entry.sh"]

--- a/backend/socket-io-client.js
+++ b/backend/socket-io-client.js
@@ -11,6 +11,10 @@ class SocketIoClient {
     this.client = io(this.serverUrl, this.options); // Pass options to io()
   }
 
+  disconnect() {
+    this.client?.disconnect();
+  }
+
   waitForConnection() {
     return new Promise((resolve) => {
       if (this.client && this.client.connected) {

--- a/entry.sh
+++ b/entry.sh
@@ -31,4 +31,4 @@ load_secrets() {
 # Load secrets
 load_secrets
 # Launch Jellystat
-npm run start
+exec "$@"


### PR DESCRIPTION
When shutting down the containers, signals are not being properly forwarded from the script/npm to node. This results in a slow shutdown time. The fix for this is to modify the entry.sh file and use exec so that it doesn't eat PID 1. See [here](https://www.docker.com/blog/docker-best-practices-choosing-between-run-cmd-and-entrypoint/) for best practices on achieving this.

Some node images also run into issues with forwarding these signals to child processes, most often being debian. The builder and base image should be replaced with alpine3.23 distro as it does not encounter these issues. See npm/cli#6684 for discussion on this.

Proper shutdown functions should be implemented to close out all websocket connections and shut down the websocket, http, and knex servers/clients.


For transparency, I am pretty new to the node ecosystem (and to some extent, js as a whole) so I did reference an LLM at some points for direction. All code was loosely based on existing FOSS projects or stackoverflow posts.