### PR TITLE
feat: add Jellyfin auth, Quick Connect, profile modal, and theming

### DIFF
--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -10,6 +10,7 @@ const { randomUUID } = require("crypto");
 const configClass = require("../classes/config");
 const { checkForUpdates } = require("../version-control");
 const API = require("../classes/api-loader");
+const { axios } = require("../classes/axios");
 const { sendUpdate } = require("../ws");
 const { tables } = require("../global/backup_tables");
 const TaskScheduler = require("../classes/task-scheduler-singleton");
@@ -158,9 +159,21 @@ router.get("/getconfig", async (req, res) => {
       res.send({ error: config.error });
       return;
     }
+    let systemInfo = {};
+    try {
+      const systemInfoResponse = await axios.get(`${config.JF_HOST}/system/info`, {
+        headers: {
+          Authorization: 'MediaBrowser Token="' + config.JF_API_KEY + '"',
+        },
+      });
+      systemInfo = systemInfoResponse?.data || {};
+    } catch (error) {
+      console.log("[JELLYSTAT] Unable to fetch server name", error?.response?.status || error?.code || error?.message);
+    }
 
     const payload = {
       JF_HOST: config.JF_HOST,
+      SERVER_NAME: systemInfo?.ServerName || systemInfo?.Name || null,
       APP_USER: config.APP_USER,
       settings: config.settings,
       REQUIRE_LOGIN: config.REQUIRE_LOGIN,

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -5,6 +5,7 @@ const jwt = require("jsonwebtoken");
 const configClass = require("../classes/config");
 const packageJson = require("../../package.json");
 const API = require("../classes/api-loader");
+const { axios } = require("../classes/axios");
 
 const JWT_SECRET = process.env.JWT_SECRET;
 const JS_USER = process.env.JS_USER;
@@ -15,6 +16,50 @@ if (JWT_SECRET === undefined) {
 }
 
 const router = express.Router();
+
+function createJellystatToken(user, res) {
+  jwt.sign({ user }, JWT_SECRET, (err, token) => {
+    if (err) {
+      console.log(err);
+      res.sendStatus(500);
+    } else {
+      res.json({ token });
+    }
+  });
+}
+
+function jellyfinAuthorizationHeader() {
+  return `MediaBrowser Client="Jellystat", Device="Jellystat Web", DeviceId="jellystat-web", Version="${packageJson.version}"`;
+}
+
+function jellyfinQuickConnectUrl(jellyfinHost) {
+  return `${jellyfinHost.replace(/\/$/, "")}/web/index.html#!/quickconnect.html`;
+}
+
+async function getConfiguredJellyfinHost(res) {
+  const config = await new configClass().getConfig();
+
+  if (config.state !== 2 || !config.JF_HOST) {
+    res.sendStatus(400);
+    return null;
+  }
+
+  return config.JF_HOST;
+}
+
+function createJellyfinUserToken(authenticationResult, res) {
+  if (!authenticationResult?.User?.Policy?.IsAdministrator) {
+    return res.sendStatus(403);
+  }
+
+  const user = {
+    id: authenticationResult.User.Id,
+    username: authenticationResult.User.Name,
+    provider: "jellyfin",
+  };
+
+  createJellystatToken(user, res);
+}
 
 router.post("/login", async (req, res) => {
   try {
@@ -38,20 +83,164 @@ router.post("/login", async (req, res) => {
 
     if (loginUser.length > 0 || (username === JS_USER && password === CryptoJS.SHA3(JS_PASSWORD).toString())) {
       const user = { id: 1, username: username };
-
-      jwt.sign({ user }, JWT_SECRET, (err, token) => {
-        if (err) {
-          console.log(err);
-          res.sendStatus(500);
-        } else {
-          res.json({ token });
-        }
-      });
+      createJellystatToken(user, res);
     } else {
       res.sendStatus(401);
     }
   } catch (error) {
     console.log(error);
+  }
+});
+
+router.post("/jellyfinLogin", async (req, res) => {
+  try {
+    const { username, password } = req.body;
+    const jellyfinHost = await getConfiguredJellyfinHost(res);
+
+    if (!jellyfinHost) {
+      return;
+    }
+
+    if (!username || !password) {
+      return res.sendStatus(401);
+    }
+
+    const response = await axios.post(
+      `${jellyfinHost}/Users/AuthenticateByName`,
+      {
+        Username: username,
+        Pw: password,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "X-Emby-Authorization": jellyfinAuthorizationHeader(),
+        },
+      }
+    );
+
+    createJellyfinUserToken(response.data, res);
+  } catch (error) {
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      return res.sendStatus(error.response.status);
+    }
+    console.log(error);
+    res.sendStatus(500);
+  }
+});
+
+router.get("/jellyfinQuickConnect/enabled", async (req, res) => {
+  try {
+    const jellyfinHost = await getConfiguredJellyfinHost(res);
+    if (!jellyfinHost) {
+      return;
+    }
+
+    const response = await axios.get(`${jellyfinHost}/QuickConnect/Enabled`, {
+      headers: {
+        "X-Emby-Authorization": jellyfinAuthorizationHeader(),
+      },
+    });
+
+    res.json({ enabled: response.data === true });
+  } catch (error) {
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      return res.json({ enabled: false });
+    }
+    console.log(error);
+    res.sendStatus(500);
+  }
+});
+
+router.post("/jellyfinQuickConnect/initiate", async (req, res) => {
+  try {
+    const jellyfinHost = await getConfiguredJellyfinHost(res);
+    if (!jellyfinHost) {
+      return;
+    }
+
+    const response = await axios.post(`${jellyfinHost}/QuickConnect/Initiate`, null, {
+      headers: {
+        "X-Emby-Authorization": jellyfinAuthorizationHeader(),
+      },
+    });
+
+    res.json({
+      ...response.data,
+      AuthorizeUrl: jellyfinQuickConnectUrl(jellyfinHost),
+    });
+  } catch (error) {
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      return res.sendStatus(error.response.status);
+    }
+    console.log(error);
+    res.sendStatus(500);
+  }
+});
+
+router.get("/jellyfinQuickConnect/status", async (req, res) => {
+  try {
+    const jellyfinHost = await getConfiguredJellyfinHost(res);
+    const { secret } = req.query;
+
+    if (!jellyfinHost) {
+      return;
+    }
+
+    if (!secret) {
+      return res.sendStatus(400);
+    }
+
+    const response = await axios.get(`${jellyfinHost}/QuickConnect/Connect`, {
+      params: { secret },
+      headers: {
+        "X-Emby-Authorization": jellyfinAuthorizationHeader(),
+      },
+    });
+
+    res.json(response.data);
+  } catch (error) {
+    if (error.response?.status === 401 || error.response?.status === 403 || error.response?.status === 404) {
+      return res.sendStatus(error.response.status);
+    }
+    console.log(error);
+    res.sendStatus(500);
+  }
+});
+
+router.post("/jellyfinQuickConnect/login", async (req, res) => {
+  try {
+    const jellyfinHost = await getConfiguredJellyfinHost(res);
+    const { secret } = req.body;
+
+    if (!jellyfinHost) {
+      return;
+    }
+
+    if (!secret) {
+      return res.sendStatus(400);
+    }
+
+    const response = await axios.post(
+      `${jellyfinHost}/Users/AuthenticateWithQuickConnect`,
+      {
+        Secret: secret,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "X-Emby-Authorization": jellyfinAuthorizationHeader(),
+        },
+      }
+    );
+
+    createJellyfinUserToken(response.data, res);
+  } catch (error) {
+    if (error.response?.status === 401 || error.response?.status === 403 || error.response?.status === 404) {
+      return res.sendStatus(error.response.status);
+    }
+    console.log(error);
+    res.sendStatus(500);
   }
 });
 
@@ -79,15 +268,7 @@ router.post("/createuser", async (req, res) => {
       }
 
       await db.query(query, [username, password]);
-
-      jwt.sign({ user }, JWT_SECRET, (err, token) => {
-        if (err) {
-          console.log(err);
-          res.sendStatus(500);
-        } else {
-          res.json({ token });
-        }
-      });
+      createJellystatToken(user, res);
     } else {
       res.sendStatus(403);
     }

--- a/backend/routes/proxy.js
+++ b/backend/routes/proxy.js
@@ -6,6 +6,91 @@ const API = require("../classes/api-loader");
 
 const router = express.Router();
 
+router.get("/Branding/Configuration", async (req, res) => {
+  const config = await new configClass().getConfig();
+
+  if (config.error) {
+    res.send({ error: config.error });
+    return;
+  }
+
+  axios
+    .get(`${config.JF_HOST}/Branding/Configuration`)
+    .then((response) => {
+      res.send(response.data);
+    })
+    .catch((error) => {
+      res.status(error?.response?.status || 500).send("Error fetching branding configuration: " + error);
+    });
+});
+
+router.get("/Branding/Splashscreen", async (req, res) => {
+  const { format, foregroundLayer } = req.query;
+  const config = await new configClass().getConfig();
+
+  if (config.error) {
+    res.send({ error: config.error });
+    return;
+  }
+
+  axios
+    .get(`${config.JF_HOST}/Branding/Splashscreen`, {
+      params: {
+        format: format || "jpg",
+        foregroundLayer: foregroundLayer || 20,
+      },
+      responseType: "arraybuffer",
+    })
+    .then((response) => {
+      res.set("Content-Type", response.headers["content-type"] || "image/jpeg");
+      res.status(200);
+
+      if (response.headers["content-type"]?.startsWith("image/")) {
+        res.send(response.data);
+      } else {
+        res.status(500).send("Error fetching splashscreen");
+      }
+    })
+    .catch((error) => {
+      res.status(error?.response?.status || 500).send("Error fetching splashscreen: " + error);
+    });
+});
+
+async function proxyJellyfinImage(req, res, jellyfinPath, fallbackContentType) {
+  const config = await new configClass().getConfig();
+
+  if (config.error) {
+    res.send({ error: config.error });
+    return;
+  }
+
+  axios
+    .get(`${config.JF_HOST}${jellyfinPath}`, {
+      responseType: "arraybuffer",
+    })
+    .then((response) => {
+      res.set("Content-Type", response.headers["content-type"] || fallbackContentType);
+      res.status(200);
+
+      if (response.headers["content-type"]?.startsWith("image/")) {
+        res.send(response.data);
+      } else {
+        res.status(500).send("Error fetching image");
+      }
+    })
+    .catch((error) => {
+      res.status(error?.response?.status || 500).send("Error fetching image: " + error);
+    });
+}
+
+router.get("/web/favicon.ico", async (req, res) => {
+  proxyJellyfinImage(req, res, "/web/favicon.ico", "image/x-icon");
+});
+
+router.get("/web/icon-transparent.png", async (req, res) => {
+  proxyJellyfinImage(req, res, "/web/icon-transparent.png", "image/png");
+});
+
 router.get("/web/assets/img/devices/", async (req, res) => {
   const { devicename } = req.query; // Get the image URL from the query string
   const config = await new configClass().getConfig();

--- a/backend/server.js
+++ b/backend/server.js
@@ -113,7 +113,7 @@ app.use((req, res, next) => {
     return res.redirect(BASE_NAME);
   }
   // Ignore requests containing 'socket.io'
-  if (req.url.includes("socket.io") || req.url.includes("swagger") || req.url.startsWith("/backup")) {
+  if (req.url.includes("socket.io") || req.url.includes("swagger") || req.url.startsWith("/backup") || req.url.startsWith("/proxy")) {
     return next();
   }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,6 +17,9 @@ import { initReactI18next } from "react-i18next";
 
 import Loading from "./pages/components/general/loading.jsx";
 import baseUrl from "./lib/baseurl.jsx";
+import { applyThemeSettings } from "./lib/theme.jsx";
+
+applyThemeSettings();
 
 i18n
   .use(Backend)

--- a/src/lib/config.jsx
+++ b/src/lib/config.jsx
@@ -9,9 +9,10 @@ class Config {
           Authorization: `Bearer ${token}`,
         },
       });
-      const { JF_HOST, APP_USER, REQUIRE_LOGIN, settings, IS_JELLYFIN } = response.data;
+      const { JF_HOST, SERVER_NAME, APP_USER, REQUIRE_LOGIN, settings, IS_JELLYFIN } = response.data;
       return {
         hostUrl: JF_HOST,
+        serverName: SERVER_NAME,
         username: APP_USER,
         token: token,
         requireLogin: REQUIRE_LOGIN,
@@ -36,10 +37,15 @@ class Config {
   async getConfig(refreshConfig) {
     let config = localStorage.getItem("config");
     if (config != undefined && !refreshConfig) {
-      return JSON.parse(config);
+      const cachedConfig = JSON.parse(config);
+      if (cachedConfig.serverName !== undefined) {
+        return cachedConfig;
+      }
     } else {
       return await this.setConfig();
     }
+
+    return await this.setConfig();
   }
 }
 

--- a/src/lib/theme.jsx
+++ b/src/lib/theme.jsx
@@ -1,0 +1,90 @@
+export const THEME_STORAGE_KEY = "PREF_THEME";
+export const JELLYFIN_ICON_URL = "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/jellyfin.svg";
+
+export const themePresets = {
+  jellystat: {
+    label: "Jellystat",
+    colors: {
+      primary: "#5a2da5",
+      secondary: "#00A4DC",
+      background: "#1e1c22",
+      surface: "#2c2a2f",
+      tertiary: "#2f2e31",
+    },
+  },
+  jellyfin: {
+    label: "Jellyfin",
+    colors: {
+      primary: "#00A4DC",
+      secondary: "#AA5CC3",
+      background: "#101216",
+      surface: "#1c2028",
+      tertiary: "#252a34",
+    },
+  },
+};
+
+export const defaultThemeSettings = {
+  preset: "jellystat",
+  brand: "jellystat",
+  icon: "jellystat",
+  splash: "off",
+  colors: themePresets.jellystat.colors,
+};
+
+export function getServerSplashscreenUrl(baseUrl = "") {
+  return `${baseUrl}/proxy/Branding/Splashscreen?format=jpg&foregroundLayer=20`;
+}
+
+export function getServerIconUrl(baseUrl = "") {
+  return `${baseUrl}/proxy/web/icon-transparent.png`;
+}
+
+export function getThemeSettings() {
+  try {
+    const storedTheme = JSON.parse(localStorage.getItem(THEME_STORAGE_KEY) || "{}");
+    const legacyBrand = storedTheme.brand || defaultThemeSettings.brand;
+    return {
+      ...defaultThemeSettings,
+      ...storedTheme,
+      icon: storedTheme.icon || legacyBrand,
+      splash: storedTheme.splash || (legacyBrand === "server" ? "server" : defaultThemeSettings.splash),
+      colors: {
+        ...defaultThemeSettings.colors,
+        ...(storedTheme.colors || {}),
+      },
+    };
+  } catch {
+    return defaultThemeSettings;
+  }
+}
+
+export function applyThemeSettings(themeSettings = getThemeSettings()) {
+  const root = document.documentElement;
+  const colors = themeSettings.colors || defaultThemeSettings.colors;
+
+  root.style.setProperty("--primary-color", colors.primary);
+  root.style.setProperty("--secondary-color", colors.secondary);
+  root.style.setProperty("--background-color", colors.background);
+  root.style.setProperty("--secondary-background-color", colors.surface);
+  root.style.setProperty("--tertiary-background-color", colors.tertiary);
+  root.dataset.icon = themeSettings.icon || themeSettings.brand || defaultThemeSettings.icon;
+  root.dataset.splash = themeSettings.splash || defaultThemeSettings.splash;
+}
+
+export function saveThemeSettings(themeSettings) {
+  const nextTheme = {
+    ...defaultThemeSettings,
+    ...themeSettings,
+    icon: themeSettings.icon || themeSettings.brand || defaultThemeSettings.icon,
+    splash: themeSettings.splash || defaultThemeSettings.splash,
+    colors: {
+      ...defaultThemeSettings.colors,
+      ...(themeSettings.colors || {}),
+    },
+  };
+
+  localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify(nextTheme));
+  applyThemeSettings(nextTheme);
+  return nextTheme;
+}

--- a/src/pages/components/general/navbar.jsx
+++ b/src/pages/components/general/navbar.jsx
@@ -1,13 +1,107 @@
-import { Nav, Navbar as BootstrapNavbar } from "react-bootstrap";
+import { Button, Modal, Nav, Navbar as BootstrapNavbar } from "react-bootstrap";
 import { Link, useLocation } from "react-router-dom";
 import { navData } from "../../../lib/navdata";
 import LogoutBoxLineIcon from "remixicon-react/LogoutBoxLineIcon";
+import UserFillIcon from "remixicon-react/UserFillIcon";
 import logo_dark from "../../images/icon-b-512.png";
 import "../../css/navbar.css";
 import VersionCard from "./version-card";
 import { Trans } from "react-i18next";
+import { useState } from "react";
+import baseUrl from "../../../lib/baseurl";
+import {
+  defaultThemeSettings,
+  getServerIconUrl,
+  getServerSplashscreenUrl,
+  getThemeSettings,
+  JELLYFIN_ICON_URL,
+  saveThemeSettings,
+  themePresets,
+  THEME_STORAGE_KEY,
+} from "../../../lib/theme";
+
+function decodeTokenUser() {
+  try {
+    const token = localStorage.getItem("token");
+    const payload = token?.split(".")?.[1];
+    if (!payload) {
+      return {};
+    }
+
+    const normalizedPayload = payload.replace(/-/g, "+").replace(/_/g, "/");
+    return JSON.parse(window.atob(normalizedPayload))?.user || {};
+  } catch {
+    return {};
+  }
+}
+
+function ProfileAvatar({ imageUrl, size }) {
+  const [imageError, setImageError] = useState(false);
+
+  if (imageUrl && !imageError) {
+    return <img alt="" className="profile-avatar-image" src={imageUrl} onError={() => setImageError(true)} />;
+  }
+
+  return <UserFillIcon size={size} />;
+}
+
+function ServerIconMark({ className }) {
+  const [imageError, setImageError] = useState(false);
+  const imageUrl = getServerIconUrl(baseUrl);
+
+  if (!imageError) {
+    return <img alt="" className={className} src={imageUrl} onError={() => setImageError(true)} />;
+  }
+
+  return <img alt="" className="navbar-jellyfin-logo" src={JELLYFIN_ICON_URL} />;
+}
 
 export default function Navbar() {
+  const [showProfileModal, setShowProfileModal] = useState(false);
+  const [themeSettings, setThemeSettings] = useState(getThemeSettings());
+  const config = (() => {
+    try {
+      return JSON.parse(localStorage.getItem("config") || "{}");
+    } catch {
+      return {};
+    }
+  })();
+  const tokenUser = decodeTokenUser();
+  const username = tokenUser?.username || config?.username || "Jellystat";
+  const accountProvider = tokenUser?.provider === "jellyfin" ? "Jellyfin" : "Jellystat";
+  const profileImageUrl = tokenUser?.provider === "jellyfin" && tokenUser?.id
+    ? `${baseUrl}/proxy/Users/Images/Primary?id=${tokenUser.id}&quality=50`
+    : null;
+  const selectedIcon = themeSettings.icon || themeSettings.brand || defaultThemeSettings.icon;
+  const brandLabel =
+    selectedIcon === "server" ? config?.serverName || "Server" : selectedIcon === "jellyfin" ? "Jellyfin" : <Trans i18nKey="JELLYSTAT" />;
+
+  const updateTheme = (themePatch) => {
+    setThemeSettings((currentTheme) => {
+      const nextTheme = saveThemeSettings({
+        ...currentTheme,
+        ...themePatch,
+        colors: {
+          ...currentTheme.colors,
+          ...(themePatch.colors || {}),
+        },
+      });
+      return nextTheme;
+    });
+  };
+
+  const applyPreset = (presetName) => {
+    updateTheme({
+      preset: presetName,
+      colors: themePresets[presetName].colors,
+    });
+  };
+
+  const resetTheme = () => {
+    const nextTheme = saveThemeSettings(defaultThemeSettings);
+    setThemeSettings(nextTheme);
+  };
+
   const handleLogout = () => {
     localStorage.removeItem("token");
     localStorage.removeItem("config");
@@ -18,7 +112,7 @@ export default function Navbar() {
   const deleteLibraryTabKeys = () => {
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key.startsWith("PREF_")) {
+      if (key.startsWith("PREF_") && key !== THEME_STORAGE_KEY) {
         localStorage.removeItem(key);
       }
     }
@@ -30,10 +124,14 @@ export default function Navbar() {
     <BootstrapNavbar variant="dark" className=" d-flex flex-column py-0 text-center sticky-top">
       <div className="sticky-top py-md-3">
         <BootstrapNavbar.Brand as={Link} to={"/"} className="d-none d-md-inline">
-          <img src={logo_dark} style={{ height: "52px" }} className="px-2" alt="" />
-          <span>
-            <Trans i18nKey="JELLYSTAT" />
-          </span>
+          {selectedIcon === "server" ? (
+            <ServerIconMark className="navbar-server-icon" />
+          ) : selectedIcon === "jellyfin" ? (
+            <img alt="" className="navbar-jellyfin-logo" src={JELLYFIN_ICON_URL} />
+          ) : (
+            <img src={logo_dark} className="navbar-jellystat-logo" alt="" />
+          )}
+          <span className="navbar-brand-text">{brandLabel}</span>
         </BootstrapNavbar.Brand>
 
         <Nav className="flex-row flex-md-column w-100">
@@ -54,15 +152,156 @@ export default function Navbar() {
               </Nav.Link>
             );
           })}
-          <Nav.Link className="navitem  p-2 logout" href="#logout" onClick={handleLogout}>
+          <Nav.Link className="navitem p-2 logout d-md-none" href="#logout" onClick={handleLogout}>
             <LogoutBoxLineIcon />
             <span className="d-none d-md-block nav-text">
               <Trans i18nKey="MENU_TABS.LOGOUT" />
             </span>
           </Nav.Link>
+          <button
+            aria-label="Open profile"
+            className="navitem profile-navitem p-2 d-md-none"
+            type="button"
+            onClick={() => setShowProfileModal(true)}
+          >
+            <UserFillIcon />
+          </button>
         </Nav>
       </div>
+      <div className="profile-nav d-none d-md-flex">
+        <button aria-label="Open profile" className="profile-nav-button" type="button" onClick={() => setShowProfileModal(true)}>
+          <span className="profile-nav-avatar">
+            <ProfileAvatar imageUrl={profileImageUrl} size={22} />
+          </span>
+          <span className="profile-nav-meta">
+            <span className="profile-nav-label">Profile</span>
+            <span className="profile-nav-username">{username}</span>
+          </span>
+        </button>
+      </div>
       <VersionCard />
+      <Modal show={showProfileModal} onHide={() => setShowProfileModal(false)} dialogClassName="profile-modal-dialog">
+        <Modal.Header closeButton>
+          <Modal.Title>Profile</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="profile-modal-header">
+            <div className="profile-modal-avatar">
+              <ProfileAvatar imageUrl={profileImageUrl} size={34} />
+            </div>
+            <div>
+              <p className="profile-modal-name">{username}</p>
+              <p className="profile-modal-subtitle">{accountProvider} account</p>
+            </div>
+          </div>
+          <div className="profile-theme-panel">
+            <div className="profile-theme-heading">Appearance</div>
+            <div className="profile-theme-row">
+              <span>Preset</span>
+              <div className="profile-theme-segment">
+                {Object.entries(themePresets).map(([presetName, preset]) => (
+                  <button
+                    className={themeSettings.preset === presetName ? "active" : ""}
+                    key={presetName}
+                    type="button"
+                    onClick={() => applyPreset(presetName)}
+                  >
+                    {preset.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="profile-theme-row">
+              <span>Icon</span>
+              <div className="profile-theme-segment">
+                <button
+                  className={selectedIcon === "jellystat" ? "active" : ""}
+                  type="button"
+                  onClick={() => updateTheme({ icon: "jellystat", brand: "jellystat" })}
+                >
+                  Jellystat
+                </button>
+                <button
+                  className={selectedIcon === "jellyfin" ? "active" : ""}
+                  type="button"
+                  onClick={() => updateTheme({ icon: "jellyfin", brand: "jellyfin" })}
+                >
+                  Jellyfin
+                </button>
+                <button
+                  className={selectedIcon === "server" ? "active" : ""}
+                  type="button"
+                  onClick={() => updateTheme({ icon: "server", brand: "server" })}
+                >
+                  Server
+                </button>
+              </div>
+            </div>
+            {selectedIcon === "server" && (
+              <div className="profile-server-icon-preview">
+                <img src={getServerIconUrl(baseUrl)} alt="" />
+              </div>
+            )}
+            <div className="profile-theme-row">
+              <span>Splash screen</span>
+              <div className="profile-theme-segment">
+                <button
+                  className={(themeSettings.splash || defaultThemeSettings.splash) === "off" ? "active" : ""}
+                  type="button"
+                  onClick={() => updateTheme({ splash: "off" })}
+                >
+                  Off
+                </button>
+                <button
+                  className={themeSettings.splash === "server" ? "active" : ""}
+                  type="button"
+                  onClick={() => updateTheme({ splash: "server" })}
+                >
+                  Server
+                </button>
+              </div>
+            </div>
+            {themeSettings.splash === "server" && (
+              <div className="profile-server-splash-preview">
+                <img src={getServerSplashscreenUrl(baseUrl)} alt="" />
+              </div>
+            )}
+            <div className="profile-color-grid">
+              {[
+                ["primary", "Primary"],
+                ["secondary", "Accent"],
+                ["background", "Background"],
+                ["surface", "Surface"],
+              ].map(([colorKey, label]) => (
+                <label className="profile-color-control" key={colorKey}>
+                  <span>{label}</span>
+                  <input
+                    type="color"
+                    value={themeSettings.colors[colorKey]}
+                    onChange={(event) =>
+                      updateTheme({
+                        preset: "custom",
+                        colors: { [colorKey]: event.target.value },
+                      })
+                    }
+                  />
+                </label>
+              ))}
+            </div>
+            <Button className="profile-theme-reset" type="button" variant="outline-primary" onClick={resetTheme}>
+              Reset appearance
+            </Button>
+          </div>
+        </Modal.Body>
+        <Modal.Footer className="profile-modal-actions">
+          <Button variant="primary" onClick={handleLogout}>
+            <LogoutBoxLineIcon size={18} />
+            <span>
+              <Trans i18nKey="MENU_TABS.LOGOUT" />
+            </span>
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </BootstrapNavbar>
   );
 }

--- a/src/pages/css/navbar.css
+++ b/src/pages/css/navbar.css
@@ -8,19 +8,80 @@
   .navbar {
     min-height: 100vh;
     border-bottom: 1px solid  #414141  !important;
+    flex: 0 0 200px;
+    max-width: 200px;
+    min-width: 200px;
+    width: 200px;
 
   }
 }
 
 .navbar .navbar-brand{
-  margin-top: 20px;
-  font-size: 32px;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 22px;
   font-weight: 500;
+  max-width: 100%;
+  min-height: 76px;
+  padding: 0 12px;
+  width: 100%;
+}
+
+.navbar > .sticky-top {
+  width: 100%;
+}
+
+.navbar-brand-text {
+  display: block;
+  font-size: 22px;
+  line-height: 1.15;
+  margin-inline: auto;
+  max-width: 184px;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.navbar-jellystat-logo,
+.navbar-jellyfin-logo,
+.navbar-server-icon {
+  margin: 0;
+  object-fit: contain;
+  vertical-align: middle;
+}
+
+.navbar-jellyfin-logo,
+.navbar-server-icon {
+  height: 42px;
+  width: 42px;
+}
+
+.navbar-jellystat-logo {
+  height: 52px;
+  width: 52px;
+}
+
+.navbar-jellyfin-logo {
+  border-radius: 0;
+}
+
+.navbar-server-icon {
+  border-radius: 0;
+  height: 52px;
+  object-fit: cover;
+  width: 52px;
 }
 
 .navbar .navbar-nav{
+  align-items: flex-start;
+  padding-left: 0;
   width: 100%;
-  margin-top: 20px;
+  margin-top: 10px;
 }
 
 .logout
@@ -44,12 +105,13 @@
   color: white;
   font-size: 18px !important;
   text-decoration: none;
-  margin-right: 4px;
   background-color: var(--background-color) !important;
   transition: all 0.4s ease-in-out;
   border-radius: 8px;
-  margin-bottom: 10px;
-  width: 90%;
+  margin-left: 0;
+  margin-bottom: 9px;
+  min-height: 42px;
+  width: 88%;
 }
 
 @media (min-width: 768px) {
@@ -71,6 +133,7 @@
 
 .nav-link
 {
+  align-items: center;
   display: flex !important;
 }
 
@@ -79,7 +142,260 @@
   margin-left: 10px;
 }
 
+.profile-nav {
+  position: fixed;
+  bottom: 78px;
+  left: 0;
+  width: 200px;
+  padding: 0 10px;
+}
 
+.profile-nav-button,
+.profile-navitem {
+  align-items: center;
+  border: 0;
+  color: white;
+  cursor: pointer;
+  display: flex;
+}
 
+.profile-nav-button {
+  background-color: var(--background-color);
+  border-radius: 8px;
+  gap: 10px;
+  padding: 10px;
+  text-align: left;
+  transition: background-color 0.2s ease-in-out;
+  width: 100%;
+}
 
+.profile-nav-button:hover,
+.profile-nav-button:focus {
+  background-color: var(--primary-color);
+}
 
+.profile-nav-avatar,
+.profile-modal-avatar {
+  align-items: center;
+  background-color: var(--primary-color);
+  border-radius: 50%;
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.profile-nav-avatar {
+  height: 38px;
+  width: 38px;
+}
+
+.profile-nav-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.profile-nav-label {
+  color: #c9c9c9;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.profile-nav-username {
+  font-size: 15px;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-navitem {
+  justify-content: center;
+}
+
+.modal-header {
+  color: white;
+  border-bottom: none !important;
+}
+
+.modal-footer {
+  border-top: none !important;
+}
+
+.modal-content {
+  background-color: var(--secondary-background-color) !important;
+  color: white;
+}
+
+.profile-modal-dialog {
+  bottom: 14px;
+  left: 14px;
+  margin: 0;
+  max-width: calc(100vw - 28px);
+  position: fixed;
+  width: 390px;
+}
+
+.profile-modal-dialog .modal-body {
+  max-height: calc(100vh - 180px);
+  overflow-y: auto;
+}
+
+.profile-modal-header {
+  align-items: center;
+  display: flex;
+  gap: 14px;
+}
+
+.profile-modal-avatar {
+  height: 58px;
+  width: 58px;
+}
+
+.profile-avatar-image {
+  border-radius: 50%;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.profile-modal-name {
+  font-size: 22px;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.profile-modal-subtitle {
+  color: #c9c9c9;
+  margin: 4px 0 0;
+}
+
+.profile-theme-panel {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: 18px;
+  padding-top: 16px;
+}
+
+.profile-theme-heading {
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.profile-theme-row {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.profile-theme-row > span,
+.profile-color-control span {
+  color: #c9c9c9;
+  font-size: 13px;
+}
+
+.profile-theme-segment {
+  background: var(--background-color);
+  border-radius: 40px;
+  display: flex;
+  flex: 1;
+  gap: 4px;
+  padding: 4px;
+}
+
+.profile-theme-segment button {
+  background: transparent;
+  border: 0;
+  border-radius: 40px;
+  color: white;
+  flex: 1;
+  font-size: 13px;
+  height: 32px;
+  min-width: 0;
+  padding: 0 8px;
+}
+
+.profile-theme-segment button.active,
+.profile-theme-segment button:hover,
+.profile-theme-segment button:focus {
+  background: var(--primary-color);
+}
+
+.profile-color-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 14px;
+}
+
+.profile-server-icon-preview {
+  align-items: center;
+  background: var(--background-color);
+  border-radius: 8px;
+  display: flex;
+  height: 58px;
+  justify-content: center;
+  margin: 12px 0;
+  width: 100%;
+}
+
+.profile-server-icon-preview img {
+  height: 38px;
+  object-fit: contain;
+  width: 38px;
+}
+
+.profile-server-splash-preview {
+  background: var(--background-color);
+  border-radius: 8px;
+  margin: 12px 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.profile-server-splash-preview img {
+  aspect-ratio: 16 / 7;
+  display: block;
+  object-fit: cover;
+  width: 100%;
+}
+
+.profile-color-control {
+  align-items: center;
+  background: var(--background-color);
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 10px;
+}
+
+.profile-color-control input {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  height: 28px;
+  padding: 0;
+  width: 34px;
+}
+
+.profile-theme-reset {
+  margin-top: 12px;
+  width: 100%;
+}
+
+.profile-modal-actions {
+  gap: 8px;
+}
+
+.profile-modal-actions .btn {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+}
+
+.btn-close {
+  filter: invert(1) grayscale(100%) brightness(200%);
+}

--- a/src/pages/css/settings/version.css
+++ b/src/pages/css/settings/version.css
@@ -6,11 +6,18 @@
     color: white !important;
     position: fixed !important;
     bottom: 0;
-    max-width: 200px;
+    left: 0;
+    margin: 0 8px;
+    max-width: 184px;
     text-align: center;
-    width: 100%;
+    width: calc(200px - 16px);
 
   
+}
+
+.version .card-body {
+    font-size: 16px;
+    padding: 14px 8px;
 }
 
 

--- a/src/pages/css/setup.css
+++ b/src/pages/css/setup.css
@@ -12,6 +12,7 @@
   border: 0 !important;
 }
 
+.login-page,
 section {
   display: flex;
   justify-content: center;
@@ -21,10 +22,26 @@ section {
   background-position: center;
   background-size: cover;
 }
+
+.login-page.has-server-splash {
+  position: relative;
+}
+
+.login-page.has-server-splash::before {
+  background: rgba(20, 18, 24, 0.68);
+  content: "";
+  inset: 0;
+  position: absolute;
+}
+
+.login-page.has-server-splash .login-card {
+  position: relative;
+}
 .form-box {
   position: relative;
   width: 400px;
-  height: 600px;
+  min-height: 600px;
+  padding: 32px 0;
   background: var(--secondary-background-color);
   /* border: 2px solid rgba(255,255,255,0.5); */
   border-radius: 20px;
@@ -33,6 +50,168 @@ section {
   justify-content: center;
   align-items: center;
 }
+
+.login-card {
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+  justify-content: flex-start;
+  min-height: auto;
+  padding: 56px 0 48px;
+  width: min(400px, calc(100vw - 32px));
+}
+
+.login-brand {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 36px;
+}
+
+.login-brand img {
+  height: 96px;
+  width: 96px;
+}
+
+.login-brand .login-server-icon {
+  border-radius: 12px;
+  height: 96px;
+  object-fit: contain;
+  width: 96px;
+}
+
+.login-brand .login-jellyfin-logo {
+  height: 96px;
+  object-fit: contain;
+  width: 96px;
+}
+
+.login-brand h1 {
+  font-size: 38px;
+  line-height: 1;
+}
+
+.login-form {
+  width: 310px;
+}
+
+.login-provider-toggle {
+  background: var(--background-color);
+  border-radius: 40px;
+  display: flex;
+  gap: 4px;
+  margin-bottom: 28px;
+  padding: 4px;
+  width: 100%;
+}
+
+.login-provider-toggle .btn {
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 40px !important;
+  color: white !important;
+  flex: 1;
+  height: 36px;
+}
+
+.login-provider-toggle .btn.active,
+.login-provider-toggle .btn:hover {
+  background: var(--primary-color) !important;
+}
+
+.login-card .inputbox {
+  margin: 24px 0 28px;
+  width: 100%;
+}
+
+.login-card .inputbox .form-label {
+  font-size: 15px;
+}
+
+.login-card .setup-button {
+  margin-top: 4px;
+}
+
+.quick-connect-panel {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  margin-top: 16px;
+  min-height: 44px;
+  width: 100%;
+}
+
+.quick-connect-button {
+  background: transparent !important;
+  border: 1px solid var(--secondary-color) !important;
+  border-radius: 40px !important;
+  color: white !important;
+  height: 40px;
+  width: 100%;
+}
+
+.quick-connect-button:hover,
+.quick-connect-button:focus {
+  background: rgba(0, 164, 220, 0.16) !important;
+}
+
+.quick-connect-copy {
+  background: var(--primary-color) !important;
+  border: 0 !important;
+  border-radius: 40px !important;
+  color: white !important;
+  height: 34px;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.quick-connect-copy:hover,
+.quick-connect-copy:focus {
+  background: var(--secondary-color) !important;
+  color: black !important;
+}
+
+.quick-connect-link {
+  background: transparent !important;
+  border: 0 !important;
+  color: var(--secondary-color) !important;
+  font-size: 13px !important;
+  margin-top: 4px;
+  padding: 0 !important;
+}
+
+.quick-connect-link:hover,
+.quick-connect-link:focus {
+  text-decoration: underline;
+}
+
+.quick-connect-code {
+  background: var(--background-color);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  color: white;
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: 4px;
+  line-height: 1;
+  padding: 14px 18px;
+  text-align: center;
+  width: 100%;
+}
+
+.quick-connect-status,
+.quick-connect-error {
+  color: #c9c9c9;
+  font-size: 13px;
+  margin-top: 8px;
+  min-height: 18px;
+}
+
+.quick-connect-error {
+  color: #ff8e8e;
+}
+
 h2 {
   font-size: 2em;
   color: #fff;

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -16,6 +16,8 @@ import logo_dark from "./images/icon-b-512.png";
 import Loading from "./components/general/loading";
 import { Trans } from "react-i18next";
 import i18next from "i18next";
+import { getServerIconUrl, getServerSplashscreenUrl, getThemeSettings, JELLYFIN_ICON_URL } from "../lib/theme";
+import baseUrl from "../lib/baseurl";
 
 function Login() {
   const [config, setConfig] = useState(null);
@@ -23,6 +25,21 @@ function Login() {
   const [showPassword, setShowPassword] = useState(false);
   const [processing, setProcessing] = useState(false);
   const [submitButtonText, setsubmitButtonText] = useState(i18next.t("LOGIN"));
+  const [loginProvider, setLoginProvider] = useState("jellystat");
+  const [quickConnectEnabled, setQuickConnectEnabled] = useState(false);
+  const [quickConnectState, setQuickConnectState] = useState({ status: "idle" });
+  const themeSettings = getThemeSettings();
+  const selectedIcon = themeSettings.icon || themeSettings.brand;
+  const selectedSplash = themeSettings.splash || "off";
+  const serverName =
+    config?.serverName ||
+    (() => {
+      try {
+        return config?.hostUrl ? new URL(config.hostUrl).hostname : "Server";
+      } catch {
+        return "Server";
+      }
+    })();
 
   function handleFormChange(event) {
     setFormValues({ ...formValues, [event.target.name]: event.target.value });
@@ -32,18 +49,22 @@ function Login() {
     setProcessing(true);
     event.preventDefault();
 
-    let hashedPassword = CryptoJS.SHA3(formValues.JS_PASSWORD).toString();
+    if (loginProvider === "jellyfin") {
+      beginLogin(formValues.JS_USERNAME, formValues.JS_PASSWORD, "/auth/jellyfinLogin");
+      return;
+    }
 
-    beginLogin(formValues.JS_USERNAME, hashedPassword);
+    const hashedPassword = CryptoJS.SHA3(formValues.JS_PASSWORD).toString();
+    beginLogin(formValues.JS_USERNAME, hashedPassword, "/auth/login");
   }
 
-  async function beginLogin(JS_USERNAME, hashedPassword) {
+  async function beginLogin(JS_USERNAME, password, endpoint = "/auth/login") {
     axios
       .post(
-        "/auth/login",
+        endpoint,
         {
           username: JS_USERNAME,
-          password: hashedPassword,
+          password: password,
         },
         {
           headers: {
@@ -52,22 +73,17 @@ function Login() {
         }
       )
       .then(async (response) => {
-        localStorage.setItem("token", response.data.token);
-        setProcessing(false);
-        if (JS_USERNAME || response.data.token) {
-          await Config.setConfig();
-          setsubmitButtonText(i18next.t("SUCCESS"));
-          window.location.reload();
-          return;
-        }
+        handleLoginSuccess(response);
       })
       .catch((error) => {
-        let errorMessage = `Error : ${error.response.status}`;
+        let errorMessage = `Error : ${error.response?.status ?? error.code}`;
         if (error.code === "ERR_NETWORK") {
           errorMessage = i18next.t("ERROR_MESSAGES.NETWORK_ERROR");
-        } else if (error.response.status === 401) {
+        } else if (error.response?.status === 401) {
           errorMessage = i18next.t("ERROR_MESSAGES.INVALID_LOGIN");
-        } else if (error.response.status === 404) {
+        } else if (error.response?.status === 403) {
+          errorMessage = "Jellyfin administrator account required";
+        } else if (error.response?.status === 404) {
           errorMessage = i18next.t("ERROR_MESSAGES.INVALID_URL").replace("{STATUS}", error.response.status);
         }
         if (JS_USERNAME) {
@@ -76,6 +92,80 @@ function Login() {
 
         setProcessing(false);
       });
+  }
+
+  async function handleLoginSuccess(response) {
+    localStorage.setItem("token", response.data.token);
+    setProcessing(false);
+    await Config.setConfig();
+    setsubmitButtonText(i18next.t("SUCCESS"));
+    window.location.reload();
+  }
+
+  async function copyQuickConnectCode(code) {
+    if (!code) {
+      return false;
+    }
+
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(code);
+        return true;
+      }
+    } catch {
+      // Fall through to the textarea fallback below.
+    }
+
+    const input = document.createElement("textarea");
+    input.value = code;
+    input.setAttribute("readonly", "");
+    input.style.position = "fixed";
+    input.style.left = "-9999px";
+    document.body.appendChild(input);
+    input.focus();
+    input.select();
+
+    const copied = document.execCommand("copy");
+    document.body.removeChild(input);
+    return copied;
+  }
+
+  async function handleQuickConnectCopy() {
+    const copied = await copyQuickConnectCode(quickConnectState.code);
+    setQuickConnectState((currentState) => ({
+      ...currentState,
+      copied: copied,
+      copyAttempted: true,
+    }));
+  }
+
+  async function handleQuickConnectStart() {
+    setQuickConnectState({ status: "starting" });
+    try {
+      const response = await axios.post("/auth/jellyfinQuickConnect/initiate");
+      const code = response.data.Code || response.data.code;
+      const authorizeUrl = response.data.AuthorizeUrl || response.data.authorizeUrl;
+      const copied = await copyQuickConnectCode(code);
+
+      if (authorizeUrl) {
+        window.open(authorizeUrl, "_blank", "noopener,noreferrer");
+      }
+
+      setQuickConnectState({
+        status: "pending",
+        code: code,
+        secret: response.data.Secret || response.data.secret,
+        copied: copied,
+        copyAttempted: true,
+        authorizeUrl: authorizeUrl,
+      });
+    } catch (error) {
+      const status = error.response?.status;
+      setQuickConnectState({
+        status: "error",
+        message: status === 401 || status === 403 ? "Quick Connect unavailable" : `Error : ${status ?? error.code}`,
+      });
+    }
   }
 
   useEffect(() => {
@@ -98,19 +188,100 @@ function Login() {
     }
   }, [config]);
 
+  useEffect(() => {
+    if (!config) {
+      setQuickConnectEnabled(false);
+      return;
+    }
+
+    axios
+      .get("/auth/jellyfinQuickConnect/enabled")
+      .then((response) => setQuickConnectEnabled(response.data.enabled))
+      .catch(() => setQuickConnectEnabled(false));
+  }, [config]);
+
+  useEffect(() => {
+    if (quickConnectState.status !== "pending" || !quickConnectState.secret) {
+      return;
+    }
+
+    const interval = setInterval(async () => {
+      try {
+        const statusResponse = await axios.get("/auth/jellyfinQuickConnect/status", {
+          params: { secret: quickConnectState.secret },
+        });
+
+        const isAuthenticated = statusResponse.data.Authenticated || statusResponse.data.authenticated;
+        if (!isAuthenticated) {
+          return;
+        }
+
+        clearInterval(interval);
+        setQuickConnectState((currentState) => ({ ...currentState, status: "approved" }));
+        const loginResponse = await axios.post("/auth/jellyfinQuickConnect/login", {
+          secret: quickConnectState.secret,
+        });
+        await handleLoginSuccess(loginResponse);
+      } catch (error) {
+        const status = error.response?.status;
+        clearInterval(interval);
+        setQuickConnectState({
+          status: "error",
+          message: status === 403 ? "Jellyfin administrator account required" : `Error : ${status ?? error.code}`,
+        });
+      }
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [quickConnectState.secret, quickConnectState.status]);
+
   if (!config || config.token) {
     return <Loading />;
   }
 
   return (
-    <section>
-      <div className="form-box d-flex flex-column">
-        <img src={logo_dark} style={{ height: "100px" }} className="px-2" alt="" />
-        <h1>
-          <Trans i18nKey={"JELLYSTAT"} />
-        </h1>
+    <section
+      className={`login-page${selectedSplash === "server" ? " has-server-splash" : ""}`}
+      style={selectedSplash === "server" ? { backgroundImage: `url(${getServerSplashscreenUrl(baseUrl)})` } : undefined}
+    >
+      <div className="form-box login-card d-flex flex-column">
+        <div className="login-brand">
+          {selectedIcon === "server" ? (
+            <img className="login-server-icon" src={getServerIconUrl(baseUrl)} alt="" />
+          ) : selectedIcon === "jellyfin" ? (
+            <img className="login-jellyfin-logo" src={JELLYFIN_ICON_URL} alt="" />
+          ) : (
+            <img src={logo_dark} alt="" />
+          )}
+          <h1>
+            {selectedIcon === "server" ? serverName : selectedIcon === "jellyfin" ? "Jellyfin" : <Trans i18nKey={"JELLYSTAT"} />}
+          </h1>
+        </div>
 
-        <Form onSubmit={handleFormSubmit} className="mt-5">
+        <Form onSubmit={handleFormSubmit} className="login-form">
+          <div className="login-provider-toggle">
+            <Button
+              type="button"
+              className={loginProvider === "jellystat" ? "active" : ""}
+              onClick={() => {
+                setLoginProvider("jellystat");
+                setsubmitButtonText(i18next.t("LOGIN"));
+              }}
+            >
+              Jellystat
+            </Button>
+            <Button
+              type="button"
+              className={loginProvider === "jellyfin" ? "active" : ""}
+              onClick={() => {
+                setLoginProvider("jellyfin");
+                setsubmitButtonText(i18next.t("LOGIN"));
+              }}
+            >
+              Jellyfin
+            </Button>
+          </div>
+
           <Form.Group as={Row} className="inputbox">
             <Form.Control
               id="JS_USERNAME"
@@ -148,6 +319,47 @@ function Login() {
           <Button type="submit" className="setup-button">
             {processing ? `${i18next.t("VALIDATING")}...` : submitButtonText}
           </Button>
+
+          {loginProvider === "jellyfin" && quickConnectEnabled && (
+            <div className="quick-connect-panel">
+              {quickConnectState.status === "pending" || quickConnectState.status === "approved" ? (
+                <>
+                  <div className="quick-connect-code">{quickConnectState.code}</div>
+                  <div className="quick-connect-status">
+                    {quickConnectState.status === "approved"
+                      ? "Approved"
+                      : quickConnectState.copied
+                      ? "Code copied. Approve it in Jellyfin."
+                      : quickConnectState.copyAttempted
+                      ? "Could not copy automatically. Use Copy code."
+                      : "Copy this code, then approve it in Jellyfin."}
+                  </div>
+                  <Button type="button" className="quick-connect-copy" onClick={handleQuickConnectCopy}>
+                    {quickConnectState.copied ? "Copied" : "Copy code"}
+                  </Button>
+                  {quickConnectState.authorizeUrl && (
+                    <Button
+                      type="button"
+                      className="quick-connect-link"
+                      onClick={() => window.open(quickConnectState.authorizeUrl, "_blank", "noopener,noreferrer")}
+                    >
+                      Open Jellyfin
+                    </Button>
+                  )}
+                </>
+              ) : (
+                <Button
+                  type="button"
+                  className="quick-connect-button"
+                  disabled={quickConnectState.status === "starting"}
+                  onClick={handleQuickConnectStart}
+                >
+                  {quickConnectState.status === "starting" ? "Starting..." : "Quick Connect"}
+                </Button>
+              )}
+              {quickConnectState.status === "error" && <div className="quick-connect-error">{quickConnectState.message}</div>}
+            </div>
+          )}
         </Form>
       </div>
     </section>


### PR DESCRIPTION
## Add Jellyfin authentication, profile modal, and appearance customization

Closes #510, #504

### Authentication
- Added Jellyfin username/password login as an alternative to the existing Jellystat login flow
- Added Jellyfin Quick Connect support: availability check, session initiation, polling, and login token exchange

### Profile modal
- New bottom-left sidebar modal showing the currently signed-in user (read from the JWT)
- Displays Jellyfin profile images with fallback handling when no image is set
- Clearly labels whether the active session is a Jellyfin or Jellystat account
- Logout action available directly from the profile surface

### Appearance settings
- Local theme controls in the profile modal: switch between Jellystat/Jellyfin color presets, or customize primary/accent/background/surface colors individually
- Choose sidebar and login icon
- Optional Jellyfin server splash screen as login background
- Settings persist to `localStorage` and are applied on app startup

### Jellyfin branding
- App proxies Jellyfin branding assets (server splash screen, server icon)
- Server name can be displayed in place of the icon when configured

### UI polish
- Refined brand/icon sizing, centered brand text under the logo
- Left-aligned nav items
- Resized profile/version card
- Consistency pass on server/Jellyfin/Jellystat logo display

### Screenshots
| | | |
|---|---|---|
| ![img1](https://github.com/user-attachments/assets/8a9f4cdb-3995-4ef0-b71f-e57386c189ad) | ![img2](https://github.com/user-attachments/assets/d6905301-9788-4e56-8a35-a207b2b9cd78) | ![img3](https://github.com/user-attachments/assets/4b842801-90fe-43b5-a741-8a27653ddd1e) |