### PR TITLE
fix: refresh library views after stats update

### DIFF
--- a/backend/routes/sync.js
+++ b/backend/routes/sync.js
@@ -629,7 +629,7 @@ async function syncPlaybackPluginData() {
 async function updateLibraryStatsData() {
   syncTask.loggedData.push({ color: "yellow", Message: "Updating Library Stats" });
 
-  await db.query("CALL ju_update_library_stats_data()");
+  await db.query("CALL ju_update_library_stats_data()", undefined, true);
 
   syncTask.loggedData.push({ color: "dodgerblue", Message: "Library Stats Updated." });
 }


### PR DESCRIPTION
## Summary

Refresh Jellystat's materialized views after library statistics are recalculated.

## Problem

After a Jellyfin sync, `jf_libraries` can contain the correct library counts while the Libraries page continues to display stale values from `js_library_stats_overview`.

I reproduced this while validating Jellystat against Jellyfin 12.

After a completed full sync, the database contained:

- Movies: 51
- Series: 34
- Seasons: 100
- Episodes: 1019

However, the Libraries page still displayed:

- Movies: 20
- Series: 9
- Seasons: 23
- Episodes: 267

Manually running:

    REFRESH MATERIALIZED VIEW js_library_stats_overview;

immediately updated the UI to the correct 51 / 34 / 100 / 1019 counts.

## Root cause

`updateLibraryStatsData()` calls `ju_update_library_stats_data()` to write the final library counters, but the materialized views are not refreshed afterwards.

The existing `db.query()` helper already supports refreshing all entries in `db.materializedViews`.

## Change

Reuse the existing refresh mechanism:

    await db.query("CALL ju_update_library_stats_data()", undefined, true);

Because both full and partial sync call `updateLibraryStatsData()`, both paths receive the corrected behavior.

## Validation

Validated against Jellystat 1.1.11 connected to Jellyfin 12.0.0 RC5.

Before materialized view refresh:

- DB: 51 movies / 34 series / 100 seasons / 1019 episodes
- UI: 20 movies / 9 series / 23 seasons / 267 episodes

After refresh:

- UI: 51 movies / 34 series / 100 seasons / 1019 episodes

No schema changes, migrations, new dependencies, or additional helpers are required.
