### PR TITLE
feat: support negated text filters and search with "!" prefix

### DIFF
--- a/backend/classes/db-helper.js
+++ b/backend/classes/db-helper.js
@@ -44,10 +44,12 @@ function buildWhereClause(conditions) {
       } else if (typeof condition === "object") {
         const { column, field, operator, value, type } = condition;
         const conjunction = index === 0 ? "" : type ? type.toUpperCase() : "AND";
-        if (operator == "LIKE") {
-          return `${conjunction} ${column ? wrapField(column) : field} ${operator} ${value}`;
+        const target = column ? wrapField(column) : field;
+        if (operator == "NOT LIKE") {
+          // NULL NOT LIKE '%x%' evaluates to NULL (row dropped); an exclusion filter should keep NULL rows
+          return `${conjunction} (${target} IS NULL OR ${target} NOT LIKE ${value})`;
         }
-        return `${conjunction} ${column ? wrapField(column) : field} ${operator} ${value}`;
+        return `${conjunction} ${target} ${operator} ${value}`;
       }
       return "";
     })
@@ -205,6 +207,43 @@ async function query({
   }
 }
 
+// Parses a free-text filter/search term. A leading "!" negates the match (LIKE -> NOT LIKE).
+// Returns null when there is nothing to match on: non-string values (booleans, numbers), an empty
+// term, or a bare "!". Non-string values can't be used with LIKE and are ignored, as before.
+function parseTextFilter(rawValue) {
+  if (typeof rawValue !== "string") {
+    return null;
+  }
+  let term = rawValue;
+  let negate = false;
+  if (term.startsWith("!")) {
+    negate = true;
+    term = term.slice(1);
+  }
+  if (term.length === 0) {
+    return null;
+  }
+  return {
+    operator: negate ? "NOT LIKE" : "LIKE",
+    pattern: `%${term.toLowerCase()}%`,
+  };
+}
+
+// Builds a where condition for a free-text search against a (pre-lowercased) field expression.
+// Pushes the bound value onto `values` and returns the condition, or null if the search is empty.
+function buildSearchCondition(field, search, values) {
+  const parsed = parseTextFilter(search);
+  if (!parsed) {
+    return null;
+  }
+  values.push(parsed.pattern);
+  return {
+    field: field,
+    operator: parsed.operator,
+    value: `$${values.length}`,
+  };
+}
+
 function buildFilterList(query, filtersArray, filterFields) {
   if (filtersArray.length > 0) {
     query.where = query.where || [];
@@ -291,13 +330,14 @@ function buildFilterList(query, filtersArray, filterFields) {
         }
       }
 
-      if (filter.value) {
+      const textFilter = parseTextFilter(filter.value);
+      if (textFilter) {
         const whereClause = {
-          operator: "LIKE",
+          operator: textFilter.operator,
           value: `$${query.values.length + 1}`,
         };
 
-        query.values.push(`%${filter.value.toLowerCase()}%`);
+        query.values.push(textFilter.pattern);
 
         if (isColumn) {
           whereClause.column = column;
@@ -311,10 +351,10 @@ function buildFilterList(query, filtersArray, filterFields) {
             if (!query.cte.where) {
               query.cte.where = [];
             }
-            whereClause.value = `$${query.values.length + 1}`;
-            query.cte.where.push(whereClause);
+            // push a copy: mutating whereClause here would also change the placeholder already in query.where
+            query.cte.where.push({ ...whereClause, value: `$${query.values.length + 1}` });
 
-            query.values.push(`%${filter.value.toLowerCase()}%`);
+            query.values.push(textFilter.pattern);
           }
         }
       }
@@ -324,4 +364,6 @@ function buildFilterList(query, filtersArray, filterFields) {
 module.exports = {
   query,
   buildFilterList,
+  buildSearchCondition,
+  parseTextFilter,
 };

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -1400,20 +1400,19 @@ router.get("/getHistory", async (req, res) => {
     };
 
     if (search && search.length > 0) {
-      query.where = [
-        {
-          field: `LOWER(
+      const searchCondition = dbHelper.buildSearchCondition(
+        `LOWER(
           CASE 
             WHEN a."SeriesName" is null THEN a."NowPlayingItemName"
             ELSE CONCAT(a."SeriesName" , ' : S' , a."SeasonNumber" , 'E' , a."EpisodeNumber" , ' - ' , a."NowPlayingItemName")
           END 
           )`,
-          operator: "LIKE",
-          value: `$${values.length + 1}`,
-        },
-      ];
-
-      values.push(`%${search.toLowerCase()}%`);
+        search,
+        values
+      );
+      if (searchCondition) {
+        query.where = [searchCondition];
+      }
     }
 
     query.values = values;
@@ -1567,20 +1566,19 @@ router.post("/getLibraryHistory", async (req, res) => {
     values.push(libraryid);
 
     if (search && search.length > 0) {
-      query.where = [
-        {
-          field: `LOWER(
+      const searchCondition = dbHelper.buildSearchCondition(
+        `LOWER(
           CASE 
             WHEN a."SeriesName" is null THEN a."NowPlayingItemName"
             ELSE CONCAT(a."SeriesName" , ' : S' , a."SeasonNumber" , 'E' , a."EpisodeNumber" , ' - ' , a."NowPlayingItemName")
           END 
           )`,
-          operator: "LIKE",
-          value: `$${values.length + 1}`,
-        },
-      ];
-
-      values.push(`%${search.toLowerCase()}%`);
+        search,
+        values
+      );
+      if (searchCondition) {
+        query.where = [searchCondition];
+      }
     }
 
     query.values = values;
@@ -1704,19 +1702,19 @@ router.post("/getItemHistory", async (req, res) => {
     values.push(itemid);
 
     if (search && search.length > 0) {
-      query.where = [
-        {
-          field: `LOWER(
+      const searchCondition = dbHelper.buildSearchCondition(
+        `LOWER(
           CASE 
             WHEN a."SeriesName" is null THEN a."NowPlayingItemName"
             ELSE CONCAT(a."SeriesName" , ' : S' , a."SeasonNumber" , 'E' , a."EpisodeNumber" , ' - ' , a."NowPlayingItemName")
           END 
           )`,
-          operator: "LIKE",
-          value: `$${values.length + 1}`,
-        },
-      ];
-      values.push(`%${search.toLowerCase()}%`);
+        search,
+        values
+      );
+      if (searchCondition) {
+        query.where = [searchCondition];
+      }
     }
 
     query.values = values;
@@ -1828,19 +1826,19 @@ router.post("/getUserHistory", async (req, res) => {
     values.push(userid);
 
     if (search && search.length > 0) {
-      query.where = [
-        {
-          field: `LOWER(
+      const searchCondition = dbHelper.buildSearchCondition(
+        `LOWER(
           CASE 
             WHEN a."SeriesName" is null THEN a."NowPlayingItemName"
             ELSE CONCAT(a."SeriesName" , ' : S' , a."SeasonNumber" , 'E' , a."EpisodeNumber" , ' - ' , a."NowPlayingItemName")
           END 
           )`,
-          operator: "LIKE",
-          value: `$${values.length + 1}`,
-        },
-      ];
-      values.push(`%${search.toLowerCase()}%`);
+        search,
+        values
+      );
+      if (searchCondition) {
+        query.where = [searchCondition];
+      }
     }
 
     query.values = values;

--- a/backend/routes/stats.js
+++ b/backend/routes/stats.js
@@ -239,20 +239,19 @@ router.get("/getPlaybackActivity", async (req, res) => {
     };
 
     if (search && search.length > 0) {
-      query.where = [
-        {
-          field: `LOWER(
+      const searchCondition = dbHelper.buildSearchCondition(
+        `LOWER(
           CASE 
             WHEN a."SeriesName" is null THEN a."NowPlayingItemName"
             ELSE a."SeriesName"
           END 
           )`,
-          operator: "LIKE",
-          value: `$${values.length + 1}`,
-        },
-      ];
-
-      values.push(`%${search.toLowerCase()}%`);
+        search,
+        values
+      );
+      if (searchCondition) {
+        query.where = [searchCondition];
+      }
     }
 
     query.values = values;
@@ -432,13 +431,10 @@ router.post("/getLibraryItemsWithStats", async (req, res) => {
     values.push(libraryid);
 
     if (search && search.length > 0) {
-      query.where.push({
-        field: `LOWER(a."Name")`,
-        operator: "LIKE",
-        value: `$${values.length + 1}`,
-      });
-
-      values.push(`%${search.toLowerCase()}%`);
+      const searchCondition = dbHelper.buildSearchCondition(`LOWER(a."Name")`, search, values);
+      if (searchCondition) {
+        query.where.push(searchCondition);
+      }
     }
 
     query.values = values;

--- a/public/locales/en-GB/translation.json
+++ b/public/locales/en-GB/translation.json
@@ -99,6 +99,7 @@
     "CLEAR_SORT": "Clear Sort",
     "CLEAR_FILTER": "Clear Filter",
     "FILTER_BY": "Filter by",
+    "FILTER_EXCLUDE_HINT": "Type to filter, prefix with ! to exclude",
     "COLUMN_ACTIONS": "Column Actions",
     "TOGGLE_SELECT_ROW": "Toggle Select Row",
     "TOGGLE_SELECT_ALL": "Toggle Select All",

--- a/src/pages/components/activity/activity-table.jsx
+++ b/src/pages/components/activity/activity-table.jsx
@@ -152,6 +152,7 @@ export default function ActivityTable(props) {
   const columns = [
     {
       accessorKey: "UserName",
+      muiFilterTextFieldProps: { placeholder: i18next.t("ACTIVITY_TABLE.FILTER_EXCLUDE_HINT") },
       header: i18next.t("USER"),
       Cell: ({ row }) => {
         row = row.original;
@@ -164,6 +165,7 @@ export default function ActivityTable(props) {
     },
     {
       accessorKey: "RemoteEndPoint",
+      muiFilterTextFieldProps: { placeholder: i18next.t("ACTIVITY_TABLE.FILTER_EXCLUDE_HINT") },
       header: i18next.t("ACTIVITY_TABLE.IP_ADDRESS"),
 
       Cell: ({ row }) => {
@@ -190,6 +192,7 @@ export default function ActivityTable(props) {
             : row.SeriesName + " : S" + row.SeasonNumber + "E" + row.EpisodeNumber + " - " + row.NowPlayingItemName
         }`,
       field: "NowPlayingItemName",
+      muiFilterTextFieldProps: { placeholder: i18next.t("ACTIVITY_TABLE.FILTER_EXCLUDE_HINT") },
       header: i18next.t("TITLE"),
       minSize: 300,
       Cell: ({ row }) => {
@@ -205,6 +208,7 @@ export default function ActivityTable(props) {
     },
     {
       accessorKey: "Client",
+      muiFilterTextFieldProps: { placeholder: i18next.t("ACTIVITY_TABLE.FILTER_EXCLUDE_HINT") },
       header: i18next.t("ACTIVITY_TABLE.CLIENT"),
       Cell: ({ row }) => {
         row = row.original;
@@ -217,6 +221,7 @@ export default function ActivityTable(props) {
     },
     {
       accessorKey: "PlayMethod",
+      muiFilterTextFieldProps: { placeholder: i18next.t("ACTIVITY_TABLE.FILTER_EXCLUDE_HINT") },
       header: i18next.t("TRANSCODE"),
       Cell: ({ row }) => {
         row = row.original;
@@ -259,6 +264,7 @@ export default function ActivityTable(props) {
     },
     {
       accessorKey: "DeviceName",
+      muiFilterTextFieldProps: { placeholder: i18next.t("ACTIVITY_TABLE.FILTER_EXCLUDE_HINT") },
       header: i18next.t("ACTIVITY_TABLE.DEVICE"),
     },
     {


### PR DESCRIPTION
Closes #545

Column filters and the search box only supported include-style substring matching (`LIKE '%term%'`). A leading `!` now inverts the match: `!alice` excludes that user.

- `parseTextFilter()` / `buildSearchCondition()` in `db-helper.js` handle the prefix. Only string values are parsed; booleans/numbers (e.g. the documented `IsPaused: false`) are ignored as before.
- `NOT LIKE` is rendered NULL-safe: `(col IS NULL OR col NOT LIKE $n)`, so rows with a NULL Client/DeviceName/IP are kept by an exclusion filter.
- A bare `!` applies no filter (avoids excluding everything while typing).
- The six inline search `LIKE` sites in `api.js`/`stats.js` use the shared helper, so the search box gets the same behaviour.
- Fixes a latent aliasing bug in `buildFilterList`: the CTE copy of a text filter mutated the same object already pushed to `query.where`, leaving one bound parameter unreferenced.
- Activity table text columns show a placeholder hint (new en-GB key `ACTIVITY_TABLE.FILTER_EXCLUDE_HINT`, other locales fall back).

## Test plan
- [ ] Activity tab → User filter `!alice` → alice rows gone, rows with NULL Client/Device still present
- [ ] Filter `alice` → unchanged include behaviour
- [ ] Type only `!` → no filtering applied
- [ ] Search box `!breaking` → titles without "breaking"
- [ ] Library items search (`getLibraryItemsWithStats`) `!foo`
- [ ] Non-English locale → hint falls back to English, no raw key shown
